### PR TITLE
add docker image and release workflow

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -1,0 +1,32 @@
+name: "docker-release"
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build-and-push:
+    permissions:
+      contents: "read"
+
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Authorize Container Registry"
+        uses: "docker/login-action@v3.4.0"
+        with:
+          registry: "${{ secrets.AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com"
+          username: "${{ secrets.AWS_ACCESS_KEY_ID }}"
+          password: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+
+      - name: "Setup Build Environment"
+        uses: "docker/setup-buildx-action@v3.10.0"
+
+      - name: "Push Docker Image"
+        uses: "docker/build-push-action@v6.16.0"
+        with:
+          push: true
+          tags: "${{ secrets.AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/${{ github.event.repository.name }}:${{ github.ref_name }}"
+          build-args: |
+            SHA=${{ github.sha }}
+            TAG=${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM golang:1.24 AS build
+WORKDIR /build
+
+ARG SHA
+ARG TAG
+
+COPY go.mod go.mod
+COPY go.sum go.sum
+RUN go mod download
+
+COPY main.go main.go
+COPY cmd/ cmd/
+COPY pkg/ pkg/
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+    -ldflags="-s -w \
+        -X 'github.com/0xSplits/specta/pkg/runtime.sha=${SHA}' \
+        -X 'github.com/0xSplits/specta/pkg/runtime.tag=${TAG}'" \
+    -a \
+    -o specta main.go
+
+
+
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /image
+
+COPY .env .env
+COPY --from=build /build/specta .
+USER 65532:65532
+
+ENV SPECTA_HTTP_HOST="0.0.0.0"
+ENV SPECTA_LOG_LEVEL="info"
+
+ENTRYPOINT ["/image/specta"]

--- a/README.md
+++ b/README.md
@@ -78,3 +78,18 @@ Go Arch       arm64
 Go OS         darwin
 Go Version    go1.24.3
 ```
+
+# Docker
+
+See https://github.com/GoogleContainerTools/distroless
+
+```
+docker build \
+  --build-arg SHA="local-test-sha" \
+  --build-arg TAG="local-test-tag" \
+  -t specta:local .
+```
+
+```
+docker run -e SPECTA_ENVIRONMENT=development -p 7777:7777 specta:local daemon
+```


### PR DESCRIPTION
Here we add a Dockerfile and a release workflow to push a new image tag to ECR. The Dockerfile optimizes builds in stages so that Docker can make heavy use of image layer caching. We use https://github.com/GoogleContainerTools/distroless images as a security best practice. In order to make the ECR push work I created a new IAM policy dedicated to the Specta repository. 