### PR TITLE
implement metrics registry for counters and histograms

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.3
 
 require (
 	github.com/0xSplits/spectagocode v0.1.0
+	github.com/google/gofuzz v1.2.0
 	github.com/gorilla/mux v1.8.1
 	github.com/joho/godotenv v1.5.1
 	github.com/kelseyhightower/envconfig v1.4.0
@@ -13,6 +14,7 @@ require (
 	github.com/twitchtv/twirp v8.1.3+incompatible
 	github.com/xh3b4sd/logger v0.10.0
 	github.com/xh3b4sd/tracer v0.11.1
+	go.opentelemetry.io/otel v1.36.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.58.0
 	go.opentelemetry.io/otel/metric v1.36.0
 	go.opentelemetry.io/otel/sdk/metric v1.36.0
@@ -21,7 +23,7 @@ require (
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/go-logr/logr v1.4.2 // indirect
+	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -31,7 +33,6 @@ require (
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.36.0 // indirect
 	go.opentelemetry.io/otel/trace v1.36.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,12 +8,14 @@ github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6N
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
-github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
-github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
+github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
+github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=

--- a/pkg/daemon/server.go
+++ b/pkg/daemon/server.go
@@ -26,13 +26,14 @@ func (d *Daemon) Server() *server.Server {
 
 	return server.New(server.Config{
 		Han: []handler.Interface{
-			metrics.New(metrics.Config{Env: d.env, Log: d.log, Reg: d.reg}),
+			metrics.New(metrics.Config{Env: d.env, Log: d.log, Met: d.met}),
 		},
 		Int: []twirp.Interceptor{
 			failure.New(failure.Config{Log: d.log}).Method,
 		},
 		Lis: lis,
 		Log: d.log,
+		Met: d.met,
 		Mid: []mux.MiddlewareFunc{
 			cors.New(cors.Config{Log: d.log}).Handler,
 		},

--- a/pkg/daemon/server.go
+++ b/pkg/daemon/server.go
@@ -33,7 +33,6 @@ func (d *Daemon) Server() *server.Server {
 		},
 		Lis: lis,
 		Log: d.log,
-		Met: d.met,
 		Mid: []mux.MiddlewareFunc{
 			cors.New(cors.Config{Log: d.log}).Handler,
 		},

--- a/pkg/daemon/worker.go
+++ b/pkg/daemon/worker.go
@@ -9,7 +9,7 @@ import (
 func (d *Daemon) Worker() *worker.Worker {
 	return worker.New(worker.Config{
 		Han: []handler.Interface{
-			privatekey.New(privatekey.Config{Env: d.env, Log: d.log, Reg: d.reg}),
+			privatekey.New(privatekey.Config{Env: d.env, Log: d.log, Met: d.met}),
 		},
 		Log: d.log,
 	})

--- a/pkg/recorder/counter.go
+++ b/pkg/recorder/counter.go
@@ -1,0 +1,41 @@
+package recorder
+
+import (
+	"context"
+
+	"github.com/xh3b4sd/tracer"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+type CounterConfig struct {
+	Des string
+	Lab map[string][]string
+	Met metric.Meter
+	Nam string
+}
+
+type Counter struct {
+	cou metric.Float64Counter
+	lab map[string][]string
+}
+
+func NewCounter(c CounterConfig) *Counter {
+	cou, err := c.Met.Float64Counter(c.Nam, metric.WithDescription(c.Des))
+	if err != nil {
+		tracer.Panic(tracer.Mask(err))
+	}
+
+	return &Counter{
+		lab: c.Lab,
+		cou: cou,
+	}
+}
+
+func (c *Counter) Labels() map[string][]string {
+	return c.lab
+}
+
+func (c *Counter) Record(val float64, lab ...attribute.KeyValue) {
+	c.cou.Add(context.Background(), val, metric.WithAttributes(lab...))
+}

--- a/pkg/recorder/fake.go
+++ b/pkg/recorder/fake.go
@@ -1,0 +1,49 @@
+package recorder
+
+import "go.opentelemetry.io/otel/attribute"
+
+type FakeConfig struct {
+	Lab map[string][]string
+}
+
+type Fake struct {
+	// lab is the set of labels to whitelist.
+	lab map[string][]string
+	// rec contains the information recorded during a single test run.
+	rec *Recorded
+}
+
+type Recorded struct {
+	Val []float64
+	Lab []map[string]string
+}
+
+func NewFake(c FakeConfig) *Fake {
+	return &Fake{
+		lab: c.Lab,
+		rec: &Recorded{},
+	}
+}
+
+func (f *Fake) Labels() map[string][]string {
+	return f.lab
+}
+
+func (f *Fake) Record(val float64, lab ...attribute.KeyValue) {
+	{
+		f.rec.Val = append(f.rec.Val, val)
+	}
+
+	m := map[string]string{}
+	for _, x := range lab {
+		m[string(x.Key)] = x.Value.AsString()
+	}
+
+	{
+		f.rec.Lab = append(f.rec.Lab, m)
+	}
+}
+
+func (f *Fake) Recorded() *Recorded {
+	return f.rec
+}

--- a/pkg/recorder/histogram.go
+++ b/pkg/recorder/histogram.go
@@ -1,0 +1,41 @@
+package recorder
+
+import (
+	"context"
+
+	"github.com/xh3b4sd/tracer"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+type HistogramConfig struct {
+	Des string
+	Lab map[string][]string
+	Met metric.Meter
+	Nam string
+}
+
+type Histogram struct {
+	his metric.Float64Histogram
+	lab map[string][]string
+}
+
+func NewHistogram(c HistogramConfig) *Histogram {
+	his, err := c.Met.Float64Histogram(c.Nam, metric.WithDescription(c.Des))
+	if err != nil {
+		tracer.Panic(tracer.Mask(err))
+	}
+
+	return &Histogram{
+		his: his,
+		lab: c.Lab,
+	}
+}
+
+func (h *Histogram) Labels() map[string][]string {
+	return h.lab
+}
+
+func (h *Histogram) Record(val float64, lab ...attribute.KeyValue) {
+	h.his.Record(context.Background(), val, metric.WithAttributes(lab...))
+}

--- a/pkg/recorder/interface.go
+++ b/pkg/recorder/interface.go
@@ -1,0 +1,12 @@
+package recorder
+
+import "go.opentelemetry.io/otel/attribute"
+
+type Interface interface {
+	// Labels returns the whitelisted set of labels that is allowed to be recorded
+	// for the underlying metric.
+	Labels() map[string][]string
+
+	// Record tracks the given value for the underlying metric.
+	Record(val float64, lab ...attribute.KeyValue)
+}

--- a/pkg/recorder/meter.go
+++ b/pkg/recorder/meter.go
@@ -1,0 +1,29 @@
+package recorder
+
+import (
+	"fmt"
+
+	"github.com/xh3b4sd/tracer"
+	"go.opentelemetry.io/otel/exporters/prometheus"
+	otelmetric "go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+)
+
+type MeterConfig struct {
+	Env string
+}
+
+func NewMeter(c MeterConfig) otelmetric.Meter {
+	if c.Env == "" {
+		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Env must not be empty", c)))
+	}
+
+	exp, err := prometheus.New()
+	if err != nil {
+		tracer.Panic(tracer.Mask(err))
+	}
+
+	return sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(exp),
+	).Meter(fmt.Sprintf("specta.%s.splits.org", c.Env))
+}

--- a/pkg/registry/counter.go
+++ b/pkg/registry/counter.go
@@ -1,0 +1,5 @@
+package registry
+
+func (r *Registry) Counter(nam string, val float64, lab map[string]string) error {
+	return r.record(r.cou, nam, val, lab)
+}

--- a/pkg/registry/error.go
+++ b/pkg/registry/error.go
@@ -1,0 +1,20 @@
+package registry
+
+import (
+	"github.com/xh3b4sd/tracer"
+)
+
+var metricNameWhitelistError = &tracer.Error{
+	Kind: "metricNameWhitelistError",
+	Desc: "The caller used a metric name that is not registered in the whitelist.",
+}
+
+var labelKeyWhitelistError = &tracer.Error{
+	Kind: "labelKeyWhitelistError",
+	Desc: "The caller used a label key that is not registered in the whitelist.",
+}
+
+var labelValueWhitelistError = &tracer.Error{
+	Kind: "labelValueWhitelistError",
+	Desc: "The caller used a label value that is not registered in the whitelist.",
+}

--- a/pkg/registry/gauge.go
+++ b/pkg/registry/gauge.go
@@ -1,0 +1,5 @@
+package registry
+
+func (r *Registry) Gauge(nam string, val float64, lab map[string]string) error {
+	return r.record(r.gau, nam, val, lab)
+}

--- a/pkg/registry/histogram.go
+++ b/pkg/registry/histogram.go
@@ -1,0 +1,5 @@
+package registry
+
+func (r *Registry) Histogram(nam string, val float64, lab map[string]string) error {
+	return r.record(r.his, nam, val, lab)
+}

--- a/pkg/registry/interface.go
+++ b/pkg/registry/interface.go
@@ -1,45 +1,44 @@
 package registry
 
-import "go.opentelemetry.io/otel/metric"
-
-// Interface provides a mechanism for the server and worker handlers to get the
-// metrics they are interested in. This abstract metrics registry defines the
-// whitelist of available metrics. The consumers, here server and worker
-// handlers, will use the registry to get their desired metrics on demand. It is
-// important for the registry to only provide predefined metrics for timeseries
-// that we want to track deliberately. E.g. it should not be possible for the
-// outside world to create metrics or labels arbitrarily based on user input.
+// Interface provides a mechanism for the server and worker handlers to record
+// the metrics they are responsible for. This abstract metrics registry defines
+// the whitelist of available metrics. The consumers, here Specta's server and
+// worker handlers, use this registry to manage their desired metrics on demand.
+// It is important for the registry to only provide predefined metrics for
+// timeseries that we want to track deliberately. E.g. it should not be possible
+// for the outside world to create metrics or labels arbitrarily based on user
+// input.
 type Interface interface {
-	// Counter performs a registry lookup for the counter metric matching the
-	// provided metric name.
+	// Counter performs a metrics update for the counter metric matching the
+	// provided metric name, if the given input is considered valid.
 	//
 	//     inp[0] the name of the counter metric to fetch
+	//     inp[1] the value of the counter metric to record
+	//     inp[2] the labels of the counter metric to associate
 	//
-	//     out[0] the interface of the counter metric to work with
-	//     out[1] the set of whitelisted labels to work with, if any
-	//     out[2] the error describing why the lookup failed, if any
+	//     out[0] the error describing why the operation failed, if any
 	//
-	Counter(string) (metric.Float64Counter, map[string]struct{}, error)
+	Counter(string, float64, map[string]string) error
 
-	// Gauge performs a registry lookup for the gauge metric matching the provided
-	// metric name.
+	// Gauge performs a metrics update for the gauge metric matching the provided
+	// metric name, if the given input is considered valid.
 	//
 	//     inp[0] the name of the gauge metric to fetch
+	//     inp[1] the value of the gauge metric to record
+	//     inp[2] the labels of the gauge metric to associate
 	//
-	//     out[0] the interface of the gauge metric to work with
-	//     out[1] the set of whitelisted labels to work with, if any
-	//     out[2] the error describing why the lookup failed, if any
+	//     out[0] the error describing why the operation failed, if any
 	//
-	Gauge(string) (metric.Float64Gauge, map[string]struct{}, error)
+	Gauge(string, float64, map[string]string) error
 
-	// Histogram performs a registry lookup for the histogram metric matching the
-	// provided metric name.
+	// Histogram performs a metrics update for the histogram metric matching the
+	// provided metric name, if the given input is considered valid.
 	//
 	//     inp[0] the name of the histogram metric to fetch
+	//     inp[1] the value of the histogram metric to record
+	//     inp[2] the labels of the histogram metric to associate
 	//
-	//     out[0] the interface of the histogram metric to work with
-	//     out[1] the set of whitelisted labels to work with, if any
-	//     out[2] the error describing why the lookup failed, if any
+	//     out[0] the error describing why the operation failed, if any
 	//
-	Histogram(string) (metric.Float64Histogram, map[string]struct{}, error)
+	Histogram(string, float64, map[string]string) error
 }

--- a/pkg/registry/record.go
+++ b/pkg/registry/record.go
@@ -1,0 +1,58 @@
+package registry
+
+import (
+	"slices"
+
+	"github.com/0xSplits/specta/pkg/recorder"
+	"github.com/xh3b4sd/tracer"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+// record validates and executes the data collection for the given metric, if
+// that metric is registered in the provided whitelist of recorder interfaces.
+// The correct metric names must be registered for the respective counters,
+// gauges and histograms. The provided labels must be registered too, by key and
+// value respectively.
+func (r *Registry) record(wht map[string]recorder.Interface, nam string, val float64, lab map[string]string) error {
+	var rec recorder.Interface
+	var exi bool
+
+	{
+		rec, exi = wht[nam]
+		if !exi {
+			return tracer.Maskf(metricNameWhitelistError, "name = %s", nam)
+		}
+	}
+
+	for k, v := range lab {
+		var lis []string
+		{
+			lis, exi = rec.Labels()[k]
+			if !exi {
+				return tracer.Maskf(labelKeyWhitelistError, "key = %s", k)
+			}
+		}
+
+		{
+			exi = slices.Contains(lis, v)
+			if !exi {
+				return tracer.Maskf(labelValueWhitelistError, "value = %s", v)
+			}
+		}
+	}
+
+	var att []attribute.KeyValue
+	{
+		att = append(att, attribute.String("env", r.env.Environment))
+	}
+
+	for k, v := range lab {
+		att = append(att, attribute.String(k, v))
+	}
+
+	{
+		rec.Record(val, att...)
+	}
+
+	return nil
+}

--- a/pkg/registry/record_test.go
+++ b/pkg/registry/record_test.go
@@ -1,0 +1,155 @@
+package registry
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/0xSplits/specta/pkg/envvar"
+	"github.com/0xSplits/specta/pkg/recorder"
+	"github.com/xh3b4sd/logger"
+)
+
+func Test_Registry_record_counter_failure(t *testing.T) {
+	testCases := []struct {
+		nam string
+		val float64
+		lab map[string]string
+		err error
+	}{
+		// Case 000, metric name not registered
+		{
+			nam: "not_allowed",
+			val: 38.5,
+			lab: map[string]string{
+				"foo": "one",
+			},
+			err: metricNameWhitelistError,
+		},
+		// Case 001, label key not registered
+		{
+			nam: "allowed_counter",
+			val: 38.5,
+			lab: map[string]string{
+				"not-allowed": "two",
+			},
+			err: labelKeyWhitelistError,
+		},
+		// Case 002, label value not registered
+		{
+			nam: "allowed_counter",
+			val: 38.5,
+			lab: map[string]string{
+				"foo": "bar",
+			},
+			err: labelValueWhitelistError,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%03d", i), func(t *testing.T) {
+			var rec *recorder.Fake
+			{
+				rec = recorder.NewFake(recorder.FakeConfig{
+					Lab: map[string][]string{
+						"foo": {"one", "two"},
+					},
+				})
+			}
+
+			var reg Interface
+			{
+				reg = New(Config{
+					Env: envvar.Env{
+						Environment: "testing",
+					},
+					Log: logger.Fake(),
+
+					Cou: map[string]recorder.Interface{
+						"allowed_counter": rec,
+					},
+					Gau: map[string]recorder.Interface{},
+					His: map[string]recorder.Interface{},
+				})
+			}
+
+			err := reg.Counter(tc.nam, tc.val, tc.lab)
+			if !errors.Is(err, tc.err) {
+				t.Fatalf("expected %#v got %#v", tc.err, err)
+			}
+
+			if rec.Recorded().Lab != nil {
+				t.Fatalf("expected %#v got %#v", nil, rec.Recorded().Lab)
+			}
+			if rec.Recorded().Val != nil {
+				t.Fatalf("expected %#v got %#v", nil, rec.Recorded().Val)
+			}
+		})
+	}
+}
+
+func Test_Registry_record_counter_success(t *testing.T) {
+	testCases := []struct {
+		nam string
+		val float64
+		lab map[string]string
+	}{
+		// Case 000
+		{
+			nam: "allowed_counter",
+			val: 38.5,
+			lab: map[string]string{
+				"foo": "one",
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%03d", i), func(t *testing.T) {
+			var rec *recorder.Fake
+			{
+				rec = recorder.NewFake(recorder.FakeConfig{
+					Lab: map[string][]string{
+						"foo": {"one", "two"},
+					},
+				})
+			}
+
+			var reg Interface
+			{
+				reg = New(Config{
+					Env: envvar.Env{
+						Environment: "testing",
+					},
+					Log: logger.Fake(),
+
+					Cou: map[string]recorder.Interface{
+						"allowed_counter": rec,
+					},
+					Gau: map[string]recorder.Interface{},
+					His: map[string]recorder.Interface{},
+				})
+			}
+
+			err := reg.Counter(tc.nam, tc.val, tc.lab)
+			if err != nil {
+				t.Fatalf("expected %#v got %#v", nil, err)
+			}
+
+			if len(rec.Recorded().Lab) != 1 {
+				t.Fatalf("expected %#v got %#v", 1, len(rec.Recorded().Lab))
+			}
+			if !reflect.DeepEqual(rec.Recorded().Lab[0], map[string]string{"env": "testing", "foo": "one"}) {
+				t.Fatalf("expected %#v got %#v", map[string]string{"env": "testing", "foo": "one"}, rec.Recorded().Lab[0])
+			}
+
+			if len(rec.Recorded().Val) != 1 {
+				t.Fatalf("expected %#v got %#v", 1, len(rec.Recorded().Val))
+			}
+			if !reflect.DeepEqual(rec.Recorded().Val[0], 38.5) {
+				t.Fatalf("expected %#v got %#v", 38.5, rec.Recorded().Val[0])
+			}
+		})
+	}
+}

--- a/pkg/registry/record_test.go
+++ b/pkg/registry/record_test.go
@@ -3,7 +3,6 @@ package registry
 import (
 	"errors"
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/0xSplits/specta/pkg/envvar"
@@ -103,6 +102,14 @@ func Test_Registry_record_counter_success(t *testing.T) {
 				"foo": "one",
 			},
 		},
+		// Case 001
+		{
+			nam: "allowed_counter",
+			val: 41.0,
+			lab: map[string]string{
+				"foo": "two",
+			},
+		},
 	}
 
 	for i, tc := range testCases {
@@ -140,15 +147,21 @@ func Test_Registry_record_counter_success(t *testing.T) {
 			if len(rec.Recorded().Lab) != 1 {
 				t.Fatalf("expected %#v got %#v", 1, len(rec.Recorded().Lab))
 			}
-			if !reflect.DeepEqual(rec.Recorded().Lab[0], map[string]string{"env": "testing", "foo": "one"}) {
-				t.Fatalf("expected %#v got %#v", map[string]string{"env": "testing", "foo": "one"}, rec.Recorded().Lab[0])
+			if len(rec.Recorded().Lab[0]) != 2 {
+				t.Fatalf("expected %#v got %#v", 2, len(rec.Recorded().Lab[0]))
+			}
+			if rec.Recorded().Lab[0]["env"] != "testing" {
+				t.Fatalf("expected %#v got %#v", "testing", rec.Recorded().Lab[0]["env"])
+			}
+			if rec.Recorded().Lab[0]["foo"] != "one" && rec.Recorded().Lab[0]["foo"] != "two" {
+				t.Fatalf("expected %#v got %#v", "one|two", rec.Recorded().Lab[0]["env"])
 			}
 
 			if len(rec.Recorded().Val) != 1 {
 				t.Fatalf("expected %#v got %#v", 1, len(rec.Recorded().Val))
 			}
-			if !reflect.DeepEqual(rec.Recorded().Val[0], 38.5) {
-				t.Fatalf("expected %#v got %#v", 38.5, rec.Recorded().Val[0])
+			if rec.Recorded().Val[0] != 38.5 && rec.Recorded().Val[0] != 41.0 {
+				t.Fatalf("expected %#v got %#v", "38.5|41.0", rec.Recorded().Val[0])
 			}
 		})
 	}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -3,60 +3,53 @@ package registry
 import (
 	"fmt"
 
+	"github.com/0xSplits/specta/pkg/envvar"
+	"github.com/0xSplits/specta/pkg/recorder"
 	"github.com/xh3b4sd/logger"
 	"github.com/xh3b4sd/tracer"
-	"go.opentelemetry.io/otel/metric"
 )
 
 type Config struct {
+	Env envvar.Env
 	Log logger.Interface
-	Met metric.Meter
+
+	Cou map[string]recorder.Interface
+	Gau map[string]recorder.Interface
+	His map[string]recorder.Interface
 }
 
 type Registry struct {
+	env envvar.Env
 	log logger.Interface
-	met metric.Meter
+
+	cou map[string]recorder.Interface
+	gau map[string]recorder.Interface
+	his map[string]recorder.Interface
 }
 
+// New creates the fully configured registry whitelisting the set of counter
+// metrics that are allowed to be tracked via the Specta RPCs.
 func New(c Config) *Registry {
 	if c.Log == nil {
 		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Log must not be empty", c)))
 	}
-	if c.Met == nil {
-		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Met must not be empty", c)))
-	}
 
-	// TODO register whitelisted metrics
-	// counter, err := c.Met.Float64Counter("foo", metric.WithDescription("a simple counter"))
-	// if err != nil {
-	// 	log.Fatal(err)
-	// }
-	// gauge, err := c.Met.Float64Gauge("foo", metric.WithDescription("a simple gauge"))
-	// if err != nil {
-	// 	log.Fatal(err)
-	// }
-	// historgam, err := c.Met.Float64Histogram("foo", metric.WithDescription("a simple histogram"))
-	// if err != nil {
-	// 	log.Fatal(err)
-	// }
+	if c.Cou == nil {
+		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Cou must not be empty", c)))
+	}
+	if c.Gau == nil {
+		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Gau must not be empty", c)))
+	}
+	if c.His == nil {
+		tracer.Panic(tracer.Mask(fmt.Errorf("%T.His must not be empty", c)))
+	}
 
 	return &Registry{
+		env: c.Env,
 		log: c.Log,
-		met: c.Met,
+
+		cou: c.Cou,
+		gau: c.Gau,
+		his: c.His,
 	}
-}
-
-func (r *Registry) Counter(string) (metric.Float64Counter, map[string]struct{}, error) {
-	// TODO implement getter for counter
-	return nil, nil, nil
-}
-
-func (r *Registry) Gauge(string) (metric.Float64Gauge, map[string]struct{}, error) {
-	// TODO implement getter for gauge
-	return nil, nil, nil
-}
-
-func (r *Registry) Histogram(string) (metric.Float64Histogram, map[string]struct{}, error) {
-	// TODO implement getter for histogram
-	return nil, nil, nil
 }

--- a/pkg/server/handler/metrics/counter.go
+++ b/pkg/server/handler/metrics/counter.go
@@ -2,12 +2,37 @@ package metrics
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/0xSplits/specta/pkg/status"
 	"github.com/0xSplits/spectagocode/pkg/metrics"
+	"github.com/xh3b4sd/tracer"
 )
 
 func (h *Handler) Counter(ctx context.Context, req *metrics.CounterI) (*metrics.CounterO, error) {
-	fmt.Printf("/metrics.API/Counter not implemented\n")
-	return &metrics.CounterO{}, nil
+	{
+		err := verify(req)
+		if err != nil {
+			return nil, tracer.Mask(err)
+		}
+	}
+
+	for _, x := range req.GetAction() {
+		err := h.reg.Counter(x.GetMetric(), x.GetNumber(), x.GetLabels())
+		if err != nil {
+			return nil, tracer.Mask(err)
+		}
+	}
+
+	var res *metrics.CounterO
+	{
+		res = &metrics.CounterO{}
+	}
+
+	for range req.GetAction() {
+		res.Result = append(res.Result, &metrics.Result{
+			Status: status.Success,
+		})
+	}
+
+	return res, nil
 }

--- a/pkg/server/handler/metrics/counter_test.go
+++ b/pkg/server/handler/metrics/counter_test.go
@@ -1,0 +1,36 @@
+package metrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/0xSplits/spectagocode/pkg/metrics"
+	fuzz "github.com/google/gofuzz"
+)
+
+func Test_Server_Handler_Metrics_Counter_Fuzz(t *testing.T) {
+	var han metrics.API
+	{
+		han = tesHan()
+	}
+
+	var fuz *fuzz.Fuzzer
+	{
+		fuz = fuzz.New()
+	}
+
+	for range 1000 {
+		var inp *metrics.CounterI
+		{
+			inp = &metrics.CounterI{}
+		}
+
+		{
+			fuz.Fuzz(inp)
+		}
+
+		{
+			_, _ = han.Counter(context.Background(), inp)
+		}
+	}
+}

--- a/pkg/server/handler/metrics/error.go
+++ b/pkg/server/handler/metrics/error.go
@@ -1,0 +1,15 @@
+package metrics
+
+import (
+	"github.com/xh3b4sd/tracer"
+)
+
+var requestInvalidError = &tracer.Error{
+	Kind: "requestInvalidError",
+	Desc: "The caller provided an invalid request with its RPC that could not be processed.",
+}
+
+var actionInvalidError = &tracer.Error{
+	Kind: "actionInvalidError",
+	Desc: "The caller provided an invalid action with its request that could not be processed.",
+}

--- a/pkg/server/handler/metrics/gauge.go
+++ b/pkg/server/handler/metrics/gauge.go
@@ -2,12 +2,16 @@ package metrics
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/0xSplits/spectagocode/pkg/metrics"
 )
 
 func (h *Handler) Gauge(ctx context.Context, req *metrics.GaugeI) (*metrics.GaugeO, error) {
-	fmt.Printf("/metrics.API/Gauge not implemented\n")
+	h.log.Log(
+		"level", "info",
+		"message", "endpoint not implemented",
+		"endpoint", "/metrics.API/Gauge",
+	)
+
 	return &metrics.GaugeO{}, nil
 }

--- a/pkg/server/handler/metrics/gauge_test.go
+++ b/pkg/server/handler/metrics/gauge_test.go
@@ -1,0 +1,36 @@
+package metrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/0xSplits/spectagocode/pkg/metrics"
+	fuzz "github.com/google/gofuzz"
+)
+
+func Test_Server_Handler_Metrics_Gauge_Fuzz(t *testing.T) {
+	var han metrics.API
+	{
+		han = tesHan()
+	}
+
+	var fuz *fuzz.Fuzzer
+	{
+		fuz = fuzz.New()
+	}
+
+	for range 1000 {
+		var inp *metrics.GaugeI
+		{
+			inp = &metrics.GaugeI{}
+		}
+
+		{
+			fuz.Fuzz(inp)
+		}
+
+		{
+			_, _ = han.Gauge(context.Background(), inp)
+		}
+	}
+}

--- a/pkg/server/handler/metrics/handler.go
+++ b/pkg/server/handler/metrics/handler.go
@@ -4,15 +4,17 @@ import (
 	"fmt"
 
 	"github.com/0xSplits/specta/pkg/envvar"
+	"github.com/0xSplits/specta/pkg/recorder"
 	"github.com/0xSplits/specta/pkg/registry"
 	"github.com/xh3b4sd/logger"
 	"github.com/xh3b4sd/tracer"
+	"go.opentelemetry.io/otel/metric"
 )
 
 type Config struct {
 	Env envvar.Env
 	Log logger.Interface
-	Reg registry.Interface
+	Met metric.Meter
 }
 
 type Handler struct {
@@ -25,13 +27,59 @@ func New(c Config) *Handler {
 	if c.Log == nil {
 		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Log must not be empty", c)))
 	}
-	if c.Reg == nil {
-		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Reg must not be empty", c)))
+	if c.Met == nil {
+		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Met must not be empty", c)))
+	}
+
+	cou := map[string]recorder.Interface{}
+
+	{
+		nam := "teams_bridge_total"
+		cou[nam] = recorder.NewCounter(recorder.CounterConfig{
+			Des: "the amount of total bridge transactions",
+			Lab: map[string][]string{
+				"success": {"true", "false"},
+			},
+			Met: c.Met,
+			Nam: nam,
+		})
+	}
+
+	gau := map[string]recorder.Interface{}
+
+	{
+		// gauges can be registered here
+	}
+
+	his := map[string]recorder.Interface{}
+
+	{
+		nam := "teams_bridge_duration_seconds"
+		cou[nam] = recorder.NewHistogram(recorder.HistogramConfig{
+			Des: "the time it takes for bridge transactions",
+			Lab: map[string][]string{
+				"success": {"true", "false"},
+			},
+			Met: c.Met,
+			Nam: nam,
+		})
+	}
+
+	var reg registry.Interface
+	{
+		reg = registry.New(registry.Config{
+			Env: c.Env,
+			Log: c.Log,
+
+			Cou: cou,
+			Gau: gau,
+			His: his,
+		})
 	}
 
 	return &Handler{
 		env: c.Env,
 		log: c.Log,
-		reg: c.Reg,
+		reg: reg,
 	}
 }

--- a/pkg/server/handler/metrics/handler_test.go
+++ b/pkg/server/handler/metrics/handler_test.go
@@ -1,0 +1,20 @@
+package metrics
+
+import (
+	"github.com/0xSplits/specta/pkg/envvar"
+	"github.com/0xSplits/specta/pkg/recorder"
+	"github.com/0xSplits/spectagocode/pkg/metrics"
+	"github.com/xh3b4sd/logger"
+)
+
+func tesHan() metrics.API {
+	return New(Config{
+		Env: envvar.Env{
+			Environment: "foo",
+		},
+		Log: logger.Fake(),
+		Met: recorder.NewMeter(recorder.MeterConfig{
+			Env: "testing",
+		}),
+	})
+}

--- a/pkg/server/handler/metrics/histogram.go
+++ b/pkg/server/handler/metrics/histogram.go
@@ -2,12 +2,37 @@ package metrics
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/0xSplits/specta/pkg/status"
 	"github.com/0xSplits/spectagocode/pkg/metrics"
+	"github.com/xh3b4sd/tracer"
 )
 
 func (h *Handler) Histogram(ctx context.Context, req *metrics.HistogramI) (*metrics.HistogramO, error) {
-	fmt.Printf("/metrics.API/Histogram not implemented\n")
-	return &metrics.HistogramO{}, nil
+	{
+		err := verify(req)
+		if err != nil {
+			return nil, tracer.Mask(err)
+		}
+	}
+
+	for _, x := range req.GetAction() {
+		err := h.reg.Histogram(x.GetMetric(), x.GetNumber(), x.GetLabels())
+		if err != nil {
+			return nil, tracer.Mask(err)
+		}
+	}
+
+	var res *metrics.HistogramO
+	{
+		res = &metrics.HistogramO{}
+	}
+
+	for range req.GetAction() {
+		res.Result = append(res.Result, &metrics.Result{
+			Status: status.Success,
+		})
+	}
+
+	return res, nil
 }

--- a/pkg/server/handler/metrics/histogram_test.go
+++ b/pkg/server/handler/metrics/histogram_test.go
@@ -1,0 +1,36 @@
+package metrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/0xSplits/spectagocode/pkg/metrics"
+	fuzz "github.com/google/gofuzz"
+)
+
+func Test_Server_Handler_Metrics_Histogram_Fuzz(t *testing.T) {
+	var han metrics.API
+	{
+		han = tesHan()
+	}
+
+	var fuz *fuzz.Fuzzer
+	{
+		fuz = fuzz.New()
+	}
+
+	for range 1000 {
+		var inp *metrics.HistogramI
+		{
+			inp = &metrics.HistogramI{}
+		}
+
+		{
+			fuz.Fuzz(inp)
+		}
+
+		{
+			_, _ = han.Histogram(context.Background(), inp)
+		}
+	}
+}

--- a/pkg/server/handler/metrics/verify.go
+++ b/pkg/server/handler/metrics/verify.go
@@ -1,0 +1,56 @@
+package metrics
+
+import (
+	"github.com/0xSplits/spectagocode/pkg/metrics"
+	"github.com/xh3b4sd/tracer"
+)
+
+const (
+	// max is the maximum amount of actions any given request is allowed to
+	// provide at once.
+	max = 100
+)
+
+type Request interface {
+	GetAction() []*metrics.Action
+}
+
+// verify ensures that the given request is properly configured within the
+// bounds of the allowed parameters. E.g. requests must provide at least one
+// action.
+func verify(req Request) error {
+	if req == nil {
+		return tracer.Maskf(requestInvalidError, "request must not be empty")
+	}
+
+	var act []*metrics.Action
+	{
+		act = req.GetAction()
+	}
+
+	{
+		if len(act) == 0 {
+			return tracer.Maskf(requestInvalidError, "request must have at least one action")
+		}
+		if len(act) > max {
+			return tracer.Maskf(requestInvalidError, "request must have at most %d actions", max)
+		}
+	}
+
+	for i, x := range act {
+		if x == nil {
+			return tracer.Maskf(actionInvalidError, "action[%d] must not be empty", i)
+		}
+		if x.GetMetric() == "" {
+			return tracer.Maskf(actionInvalidError, "action[%d] must not have empty metric name", i)
+		}
+		if len(x.GetMetric()) > 255 {
+			return tracer.Maskf(actionInvalidError, "action[%d] must not have metric name longer than 255 characters", i)
+		}
+		if x.GetNumber() < 0 {
+			return tracer.Maskf(actionInvalidError, "action[%d] must not have negative number", i)
+		}
+	}
+
+	return nil
+}

--- a/pkg/server/handler/metrics/verify_test.go
+++ b/pkg/server/handler/metrics/verify_test.go
@@ -1,0 +1,136 @@
+package metrics
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/0xSplits/spectagocode/pkg/metrics"
+)
+
+func Test_Server_Handler_Metrics_verify_failure(t *testing.T) {
+	testCases := []struct {
+		req Request
+		err error
+	}{
+		// Case 000, nil request
+		{
+			req: nil,
+			err: requestInvalidError,
+		},
+		// Case 001, no actions
+		{
+			req: &metrics.CounterI{},
+			err: requestInvalidError,
+		},
+		// Case 002, too many actions
+		{
+			req: &metrics.CounterI{
+				Action: make([]*metrics.Action, 101),
+			},
+			err: requestInvalidError,
+		},
+		// Case 003, nil action
+		{
+			req: &metrics.CounterI{
+				Action: []*metrics.Action{
+					{Metric: "valid", Number: 1},
+					nil,
+				},
+			},
+			err: actionInvalidError,
+		},
+		// Case 004, empty metric
+		{
+			req: &metrics.CounterI{
+				Action: []*metrics.Action{{Metric: ""}},
+			},
+			err: actionInvalidError,
+		},
+		// Case 005, metric name too long
+		{
+			req: &metrics.CounterI{
+				Action: []*metrics.Action{{Metric: string(make([]byte, 256))}},
+			},
+			err: actionInvalidError,
+		},
+		// Case 006, negative number
+		{
+			req: &metrics.CounterI{
+				Action: []*metrics.Action{{Metric: "ok", Number: -1}},
+			},
+			err: actionInvalidError,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%03d", i), func(t *testing.T) {
+			err := verify(tc.req)
+			if !errors.Is(err, tc.err) {
+				t.Fatalf("expected %#v got %#v", tc.err, err)
+			}
+		})
+	}
+}
+
+func Test_Server_Handler_Metrics_verify_success(t *testing.T) {
+	testCases := []struct {
+		req Request
+		err error
+	}{
+		// Case 000
+		{
+			req: &metrics.CounterI{
+				Action: []*metrics.Action{{Metric: "valid", Number: 1}},
+			},
+		},
+		// Case 001
+		{
+			req: &metrics.CounterI{
+				Action: []*metrics.Action{{Metric: "some_more_valid_counter", Number: 55.3, Labels: map[string]string{
+					"foo": "bar",
+					"baz": "zap",
+				}}},
+			},
+		},
+		// Case 002
+		{
+			req: &metrics.GaugeI{
+				Action: []*metrics.Action{{Metric: "valid", Number: 2}},
+			},
+		},
+		// Case 003
+		{
+			req: &metrics.GaugeI{
+				Action: []*metrics.Action{{Metric: "some_more_valid_gauge", Number: 2635.0028, Labels: map[string]string{
+					"hello": "world",
+				}}},
+			},
+		},
+		// Case 004
+		{
+			req: &metrics.HistogramI{
+				Action: []*metrics.Action{{Metric: "valid", Number: 3}},
+			},
+		},
+		// Case 005
+		{
+			req: &metrics.HistogramI{
+				Action: []*metrics.Action{{Metric: "some_more_valid_histogram", Number: 11.0, Labels: map[string]string{
+					"something": "something",
+					"what":      "do",
+					"you":       "know",
+				}}},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%03d", i), func(t *testing.T) {
+			err := verify(tc.req)
+			if err != nil {
+				t.Fatalf("expected %#v got %#v", nil, err)
+			}
+		})
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -12,7 +12,6 @@ import (
 	"github.com/twitchtv/twirp"
 	"github.com/xh3b4sd/logger"
 	"github.com/xh3b4sd/tracer"
-	"go.opentelemetry.io/otel/metric"
 )
 
 type Config struct {
@@ -25,8 +24,6 @@ type Config struct {
 	Lis net.Listener
 	// Log is the structured logger passed down the stack.
 	Log logger.Interface
-	// Met is the interface to create new metrics.
-	Met metric.Meter
 	// Mid are the protocol specific transport layer middlewares executed before
 	// any RPC handler.
 	Mid []mux.MiddlewareFunc

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/twitchtv/twirp"
 	"github.com/xh3b4sd/logger"
 	"github.com/xh3b4sd/tracer"
+	"go.opentelemetry.io/otel/metric"
 )
 
 type Config struct {
@@ -22,7 +23,10 @@ type Config struct {
 	Int []twirp.Interceptor
 	// Lis is the main HTTP listener bound to some configured host and port.
 	Lis net.Listener
+	// Log is the structured logger passed down the stack.
 	Log logger.Interface
+	// Met is the interface to create new metrics.
+	Met metric.Meter
 	// Mid are the protocol specific transport layer middlewares executed before
 	// any RPC handler.
 	Mid []mux.MiddlewareFunc

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -1,0 +1,6 @@
+package status
+
+const (
+	Failure = "failure"
+	Success = "success"
+)

--- a/pkg/worker/handler/privatekey/handler.go
+++ b/pkg/worker/handler/privatekey/handler.go
@@ -4,15 +4,17 @@ import (
 	"fmt"
 
 	"github.com/0xSplits/specta/pkg/envvar"
+	"github.com/0xSplits/specta/pkg/recorder"
 	"github.com/0xSplits/specta/pkg/registry"
 	"github.com/xh3b4sd/logger"
 	"github.com/xh3b4sd/tracer"
+	"go.opentelemetry.io/otel/metric"
 )
 
 type Config struct {
 	Env envvar.Env
 	Log logger.Interface
-	Reg registry.Interface
+	Met metric.Meter
 }
 
 type Handler struct {
@@ -25,13 +27,33 @@ func New(c Config) *Handler {
 	if c.Log == nil {
 		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Log must not be empty", c)))
 	}
-	if c.Reg == nil {
-		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Reg must not be empty", c)))
+	if c.Met == nil {
+		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Met must not be empty", c)))
+	}
+
+	cou := map[string]recorder.Interface{}
+	gau := map[string]recorder.Interface{}
+	his := map[string]recorder.Interface{}
+
+	{
+		// metrics can be registered here
+	}
+
+	var reg registry.Interface
+	{
+		reg = registry.New(registry.Config{
+			Env: c.Env,
+			Log: c.Log,
+
+			Cou: cou,
+			Gau: gau,
+			His: his,
+		})
 	}
 
 	return &Handler{
 		env: c.Env,
 		log: c.Log,
-		reg: c.Reg,
+		reg: reg,
 	}
 }


### PR DESCRIPTION
This is the next iteration towards enabling frontend SLOs. With this change we implement example metrics for counters and histograms, so that Specta's RPCs become useful. Here we add some critical unit tests. I would keep iterating and do some integration tests separately.