### PR TITLE
add metrics exporter for http endpoint health

### DIFF
--- a/pkg/daemon/worker.go
+++ b/pkg/daemon/worker.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/0xSplits/specta/pkg/worker"
 	"github.com/0xSplits/specta/pkg/worker/handler"
+	"github.com/0xSplits/specta/pkg/worker/handler/endpoint"
 	"github.com/0xSplits/specta/pkg/worker/handler/keypair"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -20,6 +21,8 @@ func (d *Daemon) Worker() *worker.Worker {
 
 	return worker.New(worker.Config{
 		Han: []handler.Interface{
+			endpoint.New(endpoint.Config{Env: d.env, Log: d.log, Met: d.met, Ser: "server"}),
+			endpoint.New(endpoint.Config{Env: d.env, Log: d.log, Met: d.met, Ser: "specta"}),
 			keypair.New(keypair.Config{Aws: cfg, Env: d.env, Log: d.log, Met: d.met}),
 		},
 		Log: d.log,

--- a/pkg/recorder/gauge.go
+++ b/pkg/recorder/gauge.go
@@ -1,0 +1,41 @@
+package recorder
+
+import (
+	"context"
+
+	"github.com/xh3b4sd/tracer"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+type GaugeConfig struct {
+	Des string
+	Lab map[string][]string
+	Met metric.Meter
+	Nam string
+}
+
+type Gauge struct {
+	gau metric.Float64Gauge
+	lab map[string][]string
+}
+
+func NewGauge(c GaugeConfig) *Gauge {
+	gau, err := c.Met.Float64Gauge(c.Nam, metric.WithDescription(c.Des))
+	if err != nil {
+		tracer.Panic(tracer.Mask(err))
+	}
+
+	return &Gauge{
+		lab: c.Lab,
+		gau: gau,
+	}
+}
+
+func (g *Gauge) Labels() map[string][]string {
+	return g.lab
+}
+
+func (g *Gauge) Record(val float64, lab ...attribute.KeyValue) {
+	g.gau.Record(context.Background(), val, metric.WithAttributes(lab...))
+}

--- a/pkg/worker/handler/endpoint/ensure.go
+++ b/pkg/worker/handler/endpoint/ensure.go
@@ -1,0 +1,37 @@
+package endpoint
+
+import (
+	"net/http"
+
+	"github.com/xh3b4sd/tracer"
+)
+
+func (h *Handler) Ensure() error {
+	var err error
+
+	var res *http.Response
+	{
+		res, err = http.Get(h.end)
+		if err != nil {
+			return tracer.Mask(err)
+		}
+	}
+
+	{
+		defer res.Body.Close()
+	}
+
+	var hlt float64
+	if res.StatusCode == http.StatusOK {
+		hlt = 1
+	}
+
+	{
+		err = h.reg.Gauge(Metric, hlt, map[string]string{"service": h.ser})
+		if err != nil {
+			return tracer.Mask(err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/worker/handler/endpoint/handler.go
+++ b/pkg/worker/handler/endpoint/handler.go
@@ -1,4 +1,4 @@
-package keypair
+package endpoint
 
 import (
 	"fmt"
@@ -6,53 +6,71 @@ import (
 	"github.com/0xSplits/specta/pkg/envvar"
 	"github.com/0xSplits/specta/pkg/recorder"
 	"github.com/0xSplits/specta/pkg/registry"
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/xh3b4sd/logger"
 	"github.com/xh3b4sd/tracer"
 	"go.opentelemetry.io/otel/metric"
 )
 
 const (
-	Metric = "aws_ec2_keypair_total"
+	Metric = "http_endpoint_health"
+)
+
+var (
+	endpoint = map[string]map[string]string{
+		"server": {
+			"testing":    "https://test.api.splits.org/metrics",
+			"staging":    "https://beta.api.splits.org/metrics",
+			"production": "https://api.splits.org/metrics",
+		},
+		"specta": {
+			"testing":    "https://specta.testing.splits.org/metrics",
+			"staging":    "https://specta.staging.splits.org/metrics",
+			"production": "https://specta.production.splits.org/metrics",
+		},
+	}
 )
 
 type Config struct {
-	Aws aws.Config
 	Env envvar.Env
 	Log logger.Interface
 	Met metric.Meter
+	Ser string
 }
 
 type Handler struct {
-	ec2 *ec2.Client
+	end string
 	env envvar.Env
 	log logger.Interface
 	reg registry.Interface
+	ser string
 }
 
 func New(c Config) *Handler {
-	if c.Aws.Region == "" {
-		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Aws must not be empty", c)))
-	}
 	if c.Log == nil {
 		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Log must not be empty", c)))
 	}
 	if c.Met == nil {
 		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Met must not be empty", c)))
 	}
+	if c.Ser == "" {
+		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Ser must not be empty", c)))
+	}
 
 	cou := map[string]recorder.Interface{}
 
+	gau := map[string]recorder.Interface{}
+
 	{
-		cou[Metric] = recorder.NewCounter(recorder.CounterConfig{
-			Des: "the total amount of EC2 key-pairs",
+		gau[Metric] = recorder.NewGauge(recorder.GaugeConfig{
+			Des: "the health status of an http endpoint",
+			Lab: map[string][]string{
+				"service": {"server", "specta"},
+			},
 			Met: c.Met,
 			Nam: Metric,
 		})
 	}
 
-	gau := map[string]recorder.Interface{}
 	his := map[string]recorder.Interface{}
 
 	var reg registry.Interface
@@ -68,9 +86,10 @@ func New(c Config) *Handler {
 	}
 
 	return &Handler{
-		ec2: ec2.NewFromConfig(c.Aws),
+		end: endpoint[c.Ser][c.Env.Environment],
 		env: c.Env,
 		log: c.Log,
 		reg: reg,
+		ser: c.Ser,
 	}
 }

--- a/pkg/worker/handler/keypair/ensure.go
+++ b/pkg/worker/handler/keypair/ensure.go
@@ -19,7 +19,7 @@ func (h *Handler) Ensure() error {
 	}
 
 	{
-		err = h.reg.Counter("aws_ec2_keypair_total", float64(len(out.KeyPairs)), nil)
+		err = h.reg.Counter(Metric, float64(len(out.KeyPairs)), nil)
 		if err != nil {
 			return tracer.Mask(err)
 		}


### PR DESCRIPTION
Here we add a worker handler to export metrics about the endpoint health of the configured services. For now we just track the endpoint health of the `server` and `specta` component.

```
# HELP http_endpoint_health the health status of an http endpoint
# TYPE http_endpoint_health gauge
http_endpoint_health{env="testing",otel_scope_name="specta.testing.splits.org",otel_scope_version="n/a",service="server"} 1
http_endpoint_health{env="testing",otel_scope_name="specta.testing.splits.org",otel_scope_version="n/a",service="specta"} 1
```