### PR TITLE
add container health exporter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,8 +29,10 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.36 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.36 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ecs v1.57.6
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.17 // indirect
+	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.26.6
 	github.com/aws/aws-sdk-go-v2/service/sso v1.25.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.34.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,10 +16,14 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 h1:bIqFDwgGXXN1Kpp99pDOdKMTTb5d
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3/go.mod h1:H5O/EsxDWyU+LP/V8i5sm8cxoZgc2fdNR9bxlOFrQTo=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.225.2 h1:IfMb3Ar8xEaWjgH/zeVHYD8izwJdQgRP5mKCTDt4GNk=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.225.2/go.mod h1:35jGWx7ECvCwTsApqicFYzZ7JFEnBc6oHUuOQ3xIS54=
+github.com/aws/aws-sdk-go-v2/service/ecs v1.57.6 h1:1rEJSoaC/8B9ojJYg4D6DDct0Us0Bp0tv+YPsx6JFH4=
+github.com/aws/aws-sdk-go-v2/service/ecs v1.57.6/go.mod h1:kq9VTFKJ68jqeYu1uVx6bR7VgWdQ0Kic/BstllTJJuU=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.4 h1:CXV68E2dNqhuynZJPB80bhPQwAKqBWVer887figW6Jc=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.4/go.mod h1:/xFi9KtvBXP97ppCz1TAEvU1Uf66qvid89rbem3wCzQ=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.17 h1:t0E6FzREdtCsiLIoLCWsYliNsRBgyGD/MCK571qk4MI=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.17/go.mod h1:ygpklyoaypuyDvOM5ujWGrYWpAK3h7ugnmKCU/76Ys4=
+github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.26.6 h1:PwbxovpcJvb25k019bkibvJfCpCmIANOFrXZIFPmRzk=
+github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.26.6/go.mod h1:Z4xLt5mXspLKjBV92i165wAJ/3T6TIv4n7RtIS8pWV0=
 github.com/aws/aws-sdk-go-v2/service/sso v1.25.5 h1:AIRJ3lfb2w/1/8wOOSqYb9fUKGwQbtysJ2H1MofRUPg=
 github.com/aws/aws-sdk-go-v2/service/sso v1.25.5/go.mod h1:b7SiVprpU+iGazDUqvRSLf5XmCdn+JtT1on7uNL6Ipc=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.3 h1:BpOxT3yhLwSJ77qIY3DoHAQjZsc4HEGfMCE4NGy3uFg=

--- a/pkg/daemon/worker.go
+++ b/pkg/daemon/worker.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/0xSplits/specta/pkg/worker"
 	"github.com/0xSplits/specta/pkg/worker/handler"
+	"github.com/0xSplits/specta/pkg/worker/handler/container"
 	"github.com/0xSplits/specta/pkg/worker/handler/endpoint"
 	"github.com/0xSplits/specta/pkg/worker/handler/keypair"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -21,6 +22,7 @@ func (d *Daemon) Worker() *worker.Worker {
 
 	return worker.New(worker.Config{
 		Han: []handler.Interface{
+			container.New(container.Config{Aws: cfg, Env: d.env, Log: d.log, Met: d.met}),
 			endpoint.New(endpoint.Config{Env: d.env, Log: d.log, Met: d.met, Ser: "server"}),
 			endpoint.New(endpoint.Config{Env: d.env, Log: d.log, Met: d.met, Ser: "specta"}),
 			keypair.New(keypair.Config{Aws: cfg, Env: d.env, Log: d.log, Met: d.met}),

--- a/pkg/worker/handler/container/detail.go
+++ b/pkg/worker/handler/container/detail.go
@@ -1,0 +1,62 @@
+package container
+
+import (
+	"context"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
+	tagtypes "github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi/types"
+	"github.com/xh3b4sd/tracer"
+)
+
+type detail struct {
+	// arn is the well defined Amazon Resource Name of the ECS service.
+	arn string
+	// clu is the short cluster name that the given service is part of.
+	clu string
+}
+
+// detail finds all ECS service ARNs that are tagged with the "environment" that
+// matches Specta's runtime configuration. In other words, if Specta is running
+// in "staging", then detail() will find all ECS services labelled with the
+// resource tags environment=staging.
+func (h *Handler) detail() ([]detail, error) {
+	var err error
+
+	var inp *resourcegroupstaggingapi.GetResourcesInput
+	{
+		inp = &resourcegroupstaggingapi.GetResourcesInput{
+			ResourceTypeFilters: []string{"ecs:service"},
+			TagFilters: []tagtypes.TagFilter{
+				{
+					Key:    aws.String("environment"),
+					Values: []string{h.env.Environment},
+				},
+			},
+		}
+	}
+
+	var out *resourcegroupstaggingapi.GetResourcesOutput
+	{
+		out, err = h.tag.GetResources(context.Background(), inp)
+		if err != nil {
+			return nil, tracer.Mask(err)
+		}
+	}
+
+	var det []detail
+	for _, x := range out.ResourceTagMappingList {
+		spl := strings.Split(*x.ResourceARN, "/")
+		if len(spl) != 3 {
+			return nil, tracer.Maskf(invalidAmazonResourceNameError, "%s", *x.ResourceARN)
+		}
+
+		det = append(det, detail{
+			arn: *x.ResourceARN,
+			clu: spl[len(spl)-2],
+		})
+	}
+
+	return det, nil
+}

--- a/pkg/worker/handler/container/ensure.go
+++ b/pkg/worker/handler/container/ensure.go
@@ -1,0 +1,34 @@
+package container
+
+import (
+	"github.com/xh3b4sd/tracer"
+)
+
+func (h *Handler) Ensure() error {
+	var err error
+
+	var det []detail
+	{
+		det, err = h.detail()
+		if err != nil {
+			return tracer.Mask(err)
+		}
+	}
+
+	var ser []service
+	{
+		ser, err = h.service(det)
+		if err != nil {
+			return tracer.Mask(err)
+		}
+	}
+
+	for _, x := range ser {
+		err = h.reg.Gauge(Metric, x.hlt, map[string]string{"service": x.lab})
+		if err != nil {
+			return tracer.Mask(err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/worker/handler/container/error.go
+++ b/pkg/worker/handler/container/error.go
@@ -1,0 +1,10 @@
+package container
+
+import (
+	"github.com/xh3b4sd/tracer"
+)
+
+var invalidAmazonResourceNameError = &tracer.Error{
+	Kind: "invalidAmazonResourceNameError",
+	Desc: "The exporter expected the ARN format to be [arn:aws:ecs:<region>:<account>:service/<cluster>/<service>], but a different format was found.",
+}

--- a/pkg/worker/handler/container/handler.go
+++ b/pkg/worker/handler/container/handler.go
@@ -1,0 +1,83 @@
+package container
+
+import (
+	"fmt"
+
+	"github.com/0xSplits/specta/pkg/envvar"
+	"github.com/0xSplits/specta/pkg/recorder"
+	"github.com/0xSplits/specta/pkg/registry"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	"github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
+	"github.com/xh3b4sd/logger"
+	"github.com/xh3b4sd/tracer"
+	"go.opentelemetry.io/otel/metric"
+)
+
+const (
+	Metric = "aws_ecs_container_health"
+)
+
+type Config struct {
+	Aws aws.Config
+	Env envvar.Env
+	Log logger.Interface
+	Met metric.Meter
+}
+
+type Handler struct {
+	ecs *ecs.Client
+	env envvar.Env
+	log logger.Interface
+	reg registry.Interface
+	tag *resourcegroupstaggingapi.Client
+}
+
+func New(c Config) *Handler {
+	if c.Aws.Region == "" {
+		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Aws must not be empty", c)))
+	}
+	if c.Log == nil {
+		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Log must not be empty", c)))
+	}
+	if c.Met == nil {
+		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Met must not be empty", c)))
+	}
+
+	cou := map[string]recorder.Interface{}
+
+	gau := map[string]recorder.Interface{}
+
+	{
+		gau[Metric] = recorder.NewGauge(recorder.GaugeConfig{
+			Des: "the health status of ecs service containers",
+			Lab: map[string][]string{
+				"service": {"alloy", "server", "specta", "worker"},
+			},
+			Met: c.Met,
+			Nam: Metric,
+		})
+	}
+
+	his := map[string]recorder.Interface{}
+
+	var reg registry.Interface
+	{
+		reg = registry.New(registry.Config{
+			Env: c.Env,
+			Log: c.Log,
+
+			Cou: cou,
+			Gau: gau,
+			His: his,
+		})
+	}
+
+	return &Handler{
+		ecs: ecs.NewFromConfig(c.Aws),
+		env: c.Env,
+		log: c.Log,
+		reg: reg,
+		tag: resourcegroupstaggingapi.NewFromConfig(c.Aws),
+	}
+}

--- a/pkg/worker/handler/container/service.go
+++ b/pkg/worker/handler/container/service.go
@@ -1,0 +1,88 @@
+package container
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/xh3b4sd/tracer"
+)
+
+type service struct {
+	// hlt is the binary container health status, either 0 or 1.
+	hlt float64
+	// lab is the respective service label, e.g. alloy or specta.
+	lab string
+}
+
+// service determines the binary container health of all ECS services as defined
+// by the provided list of service details. The healthy status 1 is assigned to
+// all services that have all of their desired containers running. Otherwise the
+// unhealthy status 0 is assigned.
+func (h *Handler) service(det []detail) ([]service, error) {
+	var err error
+
+	var ser []service
+	for _, x := range det {
+		var inp *ecs.DescribeServicesInput
+		{
+			inp = &ecs.DescribeServicesInput{
+				Cluster:  aws.String(x.clu),
+				Services: []string{x.arn},
+				Include:  []types.ServiceField{types.ServiceFieldTags},
+			}
+		}
+
+		var out *ecs.DescribeServicesOutput
+		{
+			out, err = h.ecs.DescribeServices(context.Background(), inp)
+			if err != nil {
+				return nil, tracer.Mask(err)
+			}
+		}
+
+		for _, y := range out.Services {
+			var tag string
+			{
+				tag = serTag(y.Tags)
+			}
+
+			if tag == "" {
+				h.log.Log(
+					"level", "warning",
+					"message", "skipping instrumentation for ECS service",
+					"reason", "ECS service has no 'service' tag",
+					"cluster", *y.ClusterArn,
+					"service", *y.ServiceArn,
+				)
+
+				{
+					continue
+				}
+			}
+
+			var hlt float64 = 1
+			if y.DesiredCount == 0 || y.RunningCount != y.DesiredCount {
+				hlt = 0
+			}
+
+			ser = append(ser, service{
+				hlt: hlt,
+				lab: tag,
+			})
+		}
+	}
+
+	return ser, nil
+}
+
+func serTag(tag []types.Tag) string {
+	for _, x := range tag {
+		if *x.Key == "service" {
+			return *x.Value
+		}
+	}
+
+	return ""
+}


### PR DESCRIPTION
This change adds a new worker handler to export the container health of all services that are tagged with the appropriate `environment` key, and any `service` key. 

```
# HELP aws_ecs_container_health the health status of ecs service containers
# TYPE aws_ecs_container_health gauge
aws_ecs_container_health{env="testing",otel_scope_name="specta.testing.splits.org",otel_scope_version="n/a",service="alloy"} 1
aws_ecs_container_health{env="testing",otel_scope_name="specta.testing.splits.org",otel_scope_version="n/a",service="server"} 1
aws_ecs_container_health{env="testing",otel_scope_name="specta.testing.splits.org",otel_scope_version="n/a",service="specta"} 1
aws_ecs_container_health{env="testing",otel_scope_name="specta.testing.splits.org",otel_scope_version="n/a",service="worker"} 1
```