### PR TITLE
add worker handler to export health status of cloudformation stacks

### DIFF
--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -13,6 +13,15 @@ jobs:
   go-build:
     runs-on: "ubuntu-latest"
     steps:
+      - name: Debug runner environment
+        run: |
+          echo "CPUs:" $(nproc)
+          lscpu | grep "Model name"
+          grep -c ^processor /proc/cpuinfo
+          free -h
+          uptime
+          vmstat 1 5
+
       - name: "Setup Git Project"
         uses: "actions/checkout@v4"
 
@@ -27,7 +36,8 @@ jobs:
           go mod tidy
           git diff --exit-code
 
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
+        id: cache-restore
         with:
           path: |
             ~/.cache/go-build
@@ -43,6 +53,15 @@ jobs:
       - name: "Check Go Formatting"
         run: |
           test -z $(gofmt -l -s .)
+
+      - uses: actions/cache/save@v4
+        id: cache-save
+        if: always() && steps.cache-restore.outputs.cache-hit != 'true'
+        with:
+          key: ${{ steps.cache-restore.outputs.cache-primary-key }}
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
 
       - name: "Check Go Linters"
         run: |

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -36,7 +36,8 @@ jobs:
           go mod tidy
           git diff --exit-code
 
-      - uses: actions/cache/restore@v4
+      - name: "Restore Go Cache"
+        uses: actions/cache/restore@v4
         id: cache-restore
         with:
           path: |
@@ -58,7 +59,8 @@ jobs:
         run: |
           test -z $(gofmt -l -s .)
 
-      - uses: actions/cache/save@v4
+      - name: "Save Go Cache"
+        uses: actions/cache/save@v4
         id: cache-save
         if: always() && steps.cache-restore.outputs.cache-hit != 'true'
         with:

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -13,7 +13,6 @@ jobs:
   go-build:
     runs-on: "ubuntu-latest"
     steps:
-
       - name: "Setup Git Project"
         uses: "actions/checkout@v4"
 
@@ -27,6 +26,15 @@ jobs:
         run: |
           go mod tidy
           git diff --exit-code
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
       - name: "Check Go Tests"
         run: |

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -46,6 +46,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
+      - name: "Run Go Build"
+        run: |
+          go build
+
       - name: "Check Go Tests"
         run: |
           go test ./... -race

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -13,15 +13,6 @@ jobs:
   go-build:
     runs-on: "ubuntu-latest"
     steps:
-      - name: Debug runner environment
-        run: |
-          echo "CPUs:" $(nproc)
-          lscpu | grep "Model name"
-          grep -c ^processor /proc/cpuinfo
-          free -h
-          uptime
-          vmstat 1 5
-
       - name: "Setup Git Project"
         uses: "actions/checkout@v4"
 
@@ -36,17 +27,6 @@ jobs:
           go mod tidy
           git diff --exit-code
 
-      - name: "Restore Go Cache"
-        uses: actions/cache/restore@v4
-        id: cache-restore
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
       - name: "Run Go Build"
         run: |
           go build
@@ -58,16 +38,6 @@ jobs:
       - name: "Check Go Formatting"
         run: |
           test -z $(gofmt -l -s .)
-
-      - name: "Save Go Cache"
-        uses: actions/cache/save@v4
-        id: cache-save
-        if: always() && steps.cache-restore.outputs.cache-hit != 'true'
-        with:
-          key: ${{ steps.cache-restore.outputs.cache-primary-key }}
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
 
       - name: "Check Go Linters"
         run: |

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.36 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.36 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 // indirect
+	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.60.3
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.57.6
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.17 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.36 h1:i2vNHQiXUvKhs3quBR
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.36/go.mod h1:UdyGa7Q91id/sdyHPwth+043HhmP6yP9MBHgbZM0xo8=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 h1:bIqFDwgGXXN1Kpp99pDOdKMTTb5d2KyU5X/BZxjOkRo=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3/go.mod h1:H5O/EsxDWyU+LP/V8i5sm8cxoZgc2fdNR9bxlOFrQTo=
+github.com/aws/aws-sdk-go-v2/service/cloudformation v1.60.3 h1:aic9qcLAqsmeYCfXElUnZOB/GRBIV2lFd1pQeJs9sVY=
+github.com/aws/aws-sdk-go-v2/service/cloudformation v1.60.3/go.mod h1:xU79X14UC0F8sEJCRTWwINzlQ4jacpEFpRESLHRHfoY=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.225.2 h1:IfMb3Ar8xEaWjgH/zeVHYD8izwJdQgRP5mKCTDt4GNk=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.225.2/go.mod h1:35jGWx7ECvCwTsApqicFYzZ7JFEnBc6oHUuOQ3xIS54=
 github.com/aws/aws-sdk-go-v2/service/ecs v1.57.6 h1:1rEJSoaC/8B9ojJYg4D6DDct0Us0Bp0tv+YPsx6JFH4=

--- a/pkg/daemon/worker.go
+++ b/pkg/daemon/worker.go
@@ -9,6 +9,7 @@ import (
 	"github.com/0xSplits/specta/pkg/worker/handler/container"
 	"github.com/0xSplits/specta/pkg/worker/handler/endpoint"
 	"github.com/0xSplits/specta/pkg/worker/handler/keypair"
+	"github.com/0xSplits/specta/pkg/worker/handler/stack"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/xh3b4sd/tracer"
@@ -25,6 +26,7 @@ func (d *Daemon) Worker() *worker.Worker {
 			container.New(container.Config{Aws: cfg, Env: d.env, Log: d.log, Met: d.met}),
 			endpoint.New(endpoint.Config{Env: d.env, Log: d.log, Met: d.met}),
 			keypair.New(keypair.Config{Aws: cfg, Env: d.env, Log: d.log, Met: d.met}),
+			stack.New(stack.Config{Aws: cfg, Env: d.env, Log: d.log, Met: d.met}),
 		},
 		Log: d.log,
 	})

--- a/pkg/worker/handler/container/detail.go
+++ b/pkg/worker/handler/container/detail.go
@@ -54,7 +54,7 @@ func (h *Handler) detail() ([]detail, error) {
 
 		det = append(det, detail{
 			arn: *x.ResourceARN,
-			clu: spl[len(spl)-2],
+			clu: spl[1],
 		})
 	}
 

--- a/pkg/worker/handler/container/handler.go
+++ b/pkg/worker/handler/container/handler.go
@@ -52,7 +52,7 @@ func New(c Config) *Handler {
 		gau[Metric] = recorder.NewGauge(recorder.GaugeConfig{
 			Des: "the health status of ecs service containers",
 			Lab: map[string][]string{
-				"service": {"alloy", "server", "specta", "worker"},
+				"service": {"alloy", "graphql", "otel-collector", "server", "specta", "worker"},
 			},
 			Met: c.Met,
 			Nam: Metric,

--- a/pkg/worker/handler/endpoint/ensure.go
+++ b/pkg/worker/handler/endpoint/ensure.go
@@ -9,7 +9,7 @@ import (
 func (h *Handler) Ensure() error {
 	var err error
 
-	for k, v := range endpoint {
+	for k, v := range mapping {
 		var sta int
 		{
 			sta = musSta(v[h.env.Environment])

--- a/pkg/worker/handler/stack/detail.go
+++ b/pkg/worker/handler/stack/detail.go
@@ -1,0 +1,98 @@
+package stack
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
+	tagtypes "github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi/types"
+	"github.com/xh3b4sd/tracer"
+)
+
+var (
+	// exp defines a regular expression for the ARN suffixes of nested
+	// CloudFormation stacks. Note that there is no precise definition for the
+	// amount of characters that a random hack suffix for the stack names ought to
+	// look like. So we are testing against at least 10 characters, but also
+	// accept e.g. 13 or 14.
+	//
+	//     arn:aws:cloudformation:us-west-2:995626699990:stack/server-test-FargateStack-QGXQ9XZ4J44K/165deb30-30d0-11f0-9eeb-023c6b26cb57
+	//
+	exp = regexp.MustCompile(`-[A-Z0-9]{10,}/[a-f0-9-]{36}$`)
+)
+
+type detail struct {
+	// arn is the well defined Amazon Resource Name of the CloudFormation stack.
+	arn string
+}
+
+// detail finds all CloudFormation stack ARNs that are tagged with the
+// "environment" that matches Specta's runtime configuration. In other words, if
+// Specta is running in "staging", then detail() will find all CloudFormation
+// stacks labelled with the resource tags environment=staging.
+func (h *Handler) detail() ([]detail, error) {
+	var err error
+
+	var inp *resourcegroupstaggingapi.GetResourcesInput
+	{
+		inp = &resourcegroupstaggingapi.GetResourcesInput{
+			ResourceTypeFilters: []string{"cloudformation:stack"},
+			TagFilters: []tagtypes.TagFilter{
+				{
+					Key:    aws.String("environment"),
+					Values: []string{h.env.Environment},
+				},
+			},
+		}
+	}
+
+	var out *resourcegroupstaggingapi.GetResourcesOutput
+	{
+		out, err = h.tag.GetResources(context.Background(), inp)
+		if err != nil {
+			return nil, tracer.Mask(err)
+		}
+	}
+
+	var det []detail
+	for _, x := range out.ResourceTagMappingList {
+		var roo bool
+		{
+			roo = rooSta(*x.ResourceARN)
+		}
+
+		if !roo {
+			continue
+		}
+
+		det = append(det, detail{
+			arn: *x.ResourceARN,
+		})
+	}
+
+	if len(det) == 0 {
+		return nil, tracer.Maskf(missingRootStackError, "%v", allArn(out.ResourceTagMappingList))
+	}
+	if len(det) > 1 {
+		return nil, tracer.Maskf(tooManyRootStacksError, "%v", det)
+	}
+
+	return det, nil
+}
+
+func allArn(lis []tagtypes.ResourceTagMapping) []string {
+	var all []string
+
+	for _, x := range lis {
+		all = append(all, *x.ResourceARN)
+	}
+
+	return all
+}
+
+// rooSta identifies whether the given CloudFormation stack ARN is considered a
+// root stack ARN.
+func rooSta(arn string) bool {
+	return !exp.MatchString(arn)
+}

--- a/pkg/worker/handler/stack/detail_test.go
+++ b/pkg/worker/handler/stack/detail_test.go
@@ -1,0 +1,68 @@
+package stack
+
+import (
+	"fmt"
+	"testing"
+)
+
+func Test_Worker_Handler_Stack_rooSta(t *testing.T) {
+	testCases := []struct {
+		arn string
+		roo bool
+	}{
+		// Case 000
+		{
+			arn: "arn:aws:cloudformation:us-west-2:995626699990:stack/server-test-SpectaStack-XQCAJRTZL8RF/9b0d7690-491f-11f0-9d9a-02e5e5b98f6f",
+			roo: false,
+		},
+		// Case 001
+		{
+			arn: "arn:aws:cloudformation:us-west-2:995626699990:stack/server-test-DiscoveryStack-1HJ4KRXNU9IZZ/7643e420-491f-11f0-8f62-0631b64352f1",
+			roo: false,
+		},
+		// Case 002
+		{
+			arn: "arn:aws:cloudformation:us-west-2:995626699990:stack/server-test-CacheStack-1CLF4ZWT6S9EZ/0b6f86e0-30ce-11f0-ad82-0a7b61ec7c77",
+			roo: false,
+		},
+		// Case 003
+		{
+			arn: "arn:aws:cloudformation:us-west-2:995626699990:stack/server-test-FargateStack-QGXQ9XZ4J44K/165deb30-30d0-11f0-9eeb-023c6b26cb57",
+			roo: false,
+		},
+		// Case 004
+		{
+			arn: "arn:aws:cloudformation:us-west-2:995626699990:stack/server-test-VpcStack-P4032W206SOD/9e159990-30cd-11f0-9975-061fb88c06d9",
+			roo: false,
+		},
+		// Case 005
+		{
+			arn: "arn:aws:cloudformation:us-west-2:995626699990:stack/server-test-TelemetryStack-1CI1X2G5NOG2J/0399cdc0-34bd-11f0-bd75-061643229203",
+			roo: false,
+		},
+		// Case 006
+		{
+			arn: "arn:aws:cloudformation:us-west-2:995626699990:stack/server-test-RdsStack-TF2N40EHYUUN/0b61a430-30ce-11f0-9e0a-06c6e436b1f3",
+			roo: false,
+		},
+		// Case 007
+		{
+			arn: "arn:aws:cloudformation:us-west-2:995626699990:stack/server-test/9c95fe70-30cd-11f0-b8b6-0a489308d945",
+			roo: true,
+		},
+		// Case 008
+		{
+			arn: "arn:aws:cloudformation:us-west-2:995626699990:stack/another-root-stack-name/9c95fe70-30cd-11f0-b8b6-0a489308d945",
+			roo: true,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%03d", i), func(t *testing.T) {
+			roo := rooSta(tc.arn)
+			if roo != tc.roo {
+				t.Fatalf("expected %#v got %#v", tc.roo, roo)
+			}
+		})
+	}
+}

--- a/pkg/worker/handler/stack/ensure.go
+++ b/pkg/worker/handler/stack/ensure.go
@@ -1,0 +1,32 @@
+package stack
+
+import "github.com/xh3b4sd/tracer"
+
+func (h *Handler) Ensure() error {
+	var err error
+
+	var det []detail
+	{
+		det, err = h.detail()
+		if err != nil {
+			return tracer.Mask(err)
+		}
+	}
+
+	var sta []stack
+	{
+		sta, err = h.stack(det)
+		if err != nil {
+			return tracer.Mask(err)
+		}
+	}
+
+	for _, x := range sta {
+		err = h.reg.Gauge(Metric, x.hlt, map[string]string{"stack": x.lab})
+		if err != nil {
+			return tracer.Mask(err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/worker/handler/stack/error.go
+++ b/pkg/worker/handler/stack/error.go
@@ -1,0 +1,15 @@
+package stack
+
+import (
+	"github.com/xh3b4sd/tracer"
+)
+
+var missingRootStackError = &tracer.Error{
+	Kind: "missingRootStackError",
+	Desc: "The exporter expected to find exactly one root stack, but no stack name matched against the internal mapping.",
+}
+
+var tooManyRootStacksError = &tracer.Error{
+	Kind: "tooManyRootStacksError",
+	Desc: "The exporter expected to find exactly one root stack, but more than one stack names matched against the internal mapping.",
+}

--- a/pkg/worker/handler/stack/stack.go
+++ b/pkg/worker/handler/stack/stack.go
@@ -1,0 +1,121 @@
+package stack
+
+import (
+	"context"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
+	"github.com/xh3b4sd/tracer"
+)
+
+var status = map[types.ResourceStatus]float64{
+	types.ResourceStatusCreateFailed:             0.0,
+	types.ResourceStatusDeleteFailed:             0.0,
+	types.ResourceStatusDeleteSkipped:            0.0,
+	types.ResourceStatusExportFailed:             0.0,
+	types.ResourceStatusExportRollbackComplete:   0.0,
+	types.ResourceStatusExportRollbackFailed:     0.0,
+	types.ResourceStatusExportRollbackInProgress: 0.0,
+	types.ResourceStatusImportFailed:             0.0,
+	types.ResourceStatusImportRollbackComplete:   0.0,
+	types.ResourceStatusImportRollbackFailed:     0.0,
+	types.ResourceStatusImportRollbackInProgress: 0.0,
+	types.ResourceStatusRollbackComplete:         0.0,
+	types.ResourceStatusRollbackFailed:           0.0,
+	types.ResourceStatusRollbackInProgress:       0.0,
+	types.ResourceStatusUpdateFailed:             0.0,
+	types.ResourceStatusUpdateRollbackComplete:   0.0,
+	types.ResourceStatusUpdateRollbackFailed:     0.0,
+	types.ResourceStatusUpdateRollbackInProgress: 0.0,
+
+	types.ResourceStatusCreateInProgress: 0.5,
+	types.ResourceStatusDeleteInProgress: 0.5,
+	types.ResourceStatusExportInProgress: 0.5,
+	types.ResourceStatusImportInProgress: 0.5,
+	types.ResourceStatusUpdateInProgress: 0.5,
+
+	types.ResourceStatusCreateComplete: 1.0,
+	types.ResourceStatusDeleteComplete: 1.0,
+	types.ResourceStatusExportComplete: 1.0,
+	types.ResourceStatusImportComplete: 1.0,
+	types.ResourceStatusUpdateComplete: 1.0,
+}
+
+type stack struct {
+	// hlt is the CloudFormation stack status, either 0.0, 0.5 or 1.0.
+	hlt float64
+	// lab is the respective stack label, e.g. root or cache.
+	lab string
+}
+
+// stack determines the CloudFormation stack health of all CloudFormation stacks
+// as defined by the provided list of stack details. The healthy status 1 is
+// assigned to all stacks that have a stack status suffix of _COMPLETE. The
+// exception here are _ROLLBACK_COMPLETE statuses. The _PROGRESS suffix is
+// assigned the stack status 0.5, otherwise the unhealthy stack status 0 is
+// assigned.
+func (h *Handler) stack(det []detail) ([]stack, error) {
+	var err error
+
+	var sta []stack
+	for _, x := range det {
+		var inp *cloudformation.DescribeStackResourcesInput
+		{
+			inp = &cloudformation.DescribeStackResourcesInput{
+				StackName: aws.String(x.arn),
+			}
+		}
+
+		var out *cloudformation.DescribeStackResourcesOutput
+		{
+			out, err = h.cfc.DescribeStackResources(context.Background(), inp)
+			if err != nil {
+				return nil, tracer.Mask(err)
+			}
+		}
+
+		for _, y := range out.StackResources {
+			var tag string
+			{
+				tag = staTag(*y.LogicalResourceId)
+			}
+
+			if tag == "" {
+				h.log.Log(
+					"level", "warning",
+					"message", "skipping instrumentation for CloudFormation stack",
+					"reason", "CloudFormation stack name pattern is unrecognizable",
+					"name", *y.LogicalResourceId,
+				)
+
+				{
+					continue
+				}
+			}
+
+			var hlt float64
+			{
+				hlt = status[y.ResourceStatus]
+			}
+
+			sta = append(sta, stack{
+				hlt: hlt,
+				lab: tag,
+			})
+		}
+	}
+
+	return sta, nil
+}
+
+func staTag(nam string) string {
+	for k, v := range mapping {
+		if strings.Contains(nam, k) {
+			return v
+		}
+	}
+
+	return ""
+}


### PR DESCRIPTION
This is to get more visibility into the health status of our CloudFormation stacks, which includes the root stacks, and their respective nested stacks.

```
# HELP aws_cloudformation_stack_health the health status of cloudformation stacks
# TYPE aws_cloudformation_stack_health gauge
aws_cloudformation_stack_health{env="testing",otel_scope_name="specta.testing.splits.org",otel_scope_version="n/a",stack="alloy"} 1
aws_cloudformation_stack_health{env="testing",otel_scope_name="specta.testing.splits.org",otel_scope_version="n/a",stack="cache"} 1
aws_cloudformation_stack_health{env="testing",otel_scope_name="specta.testing.splits.org",otel_scope_version="n/a",stack="database"} 1
aws_cloudformation_stack_health{env="testing",otel_scope_name="specta.testing.splits.org",otel_scope_version="n/a",stack="discovery"} 1
aws_cloudformation_stack_health{env="testing",otel_scope_name="specta.testing.splits.org",otel_scope_version="n/a",stack="network"} 1
aws_cloudformation_stack_health{env="testing",otel_scope_name="specta.testing.splits.org",otel_scope_version="n/a",stack="server"} 1
aws_cloudformation_stack_health{env="testing",otel_scope_name="specta.testing.splits.org",otel_scope_version="n/a",stack="specta"} 1
```