### PR TITLE
add error traces to error logs

### DIFF
--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -48,6 +48,7 @@ func (w *Worker) Daemon() {
 				w.log.Log(
 					"level", "error",
 					"message", err.Error(),
+					"stack", tracer.Stack(err),
 				)
 			}
 		}


### PR DESCRIPTION
There are these error logs in `testing` right now and I can't quite comprehend where this is coming from. Adding traces to the error logs should help.

```
{ "time":"2025-06-20 15:16:37", "level":"error", "message":"label value whitelist: value = graphql", "caller":"/build/pkg/worker/worker.go:48" }
```