### PR TITLE
instrument new deployment stack

### DIFF
--- a/pkg/worker/handler/stack/handler.go
+++ b/pkg/worker/handler/stack/handler.go
@@ -20,14 +20,15 @@ const (
 
 var (
 	mapping = map[string]string{
-		"CacheStack":     "cache",
-		"DiscoveryStack": "discovery",
-		"FargateStack":   "fargate",
-		"RdsStack":       "database",
-		"ServerStack":    "server",
-		"SpectaStack":    "specta",
-		"TelemetryStack": "alloy",
-		"VpcStack":       "network",
+		"CacheStack":      "cache",
+		"DeploymentStack": "deployment",
+		"DiscoveryStack":  "discovery",
+		"FargateStack":    "fargate",
+		"RdsStack":        "database",
+		"ServerStack":     "server",
+		"SpectaStack":     "specta",
+		"TelemetryStack":  "alloy",
+		"VpcStack":        "network",
 	}
 )
 
@@ -65,7 +66,7 @@ func New(c Config) *Handler {
 		gau[Metric] = recorder.NewGauge(recorder.GaugeConfig{
 			Des: "the health status of cloudformation stacks",
 			Lab: map[string][]string{
-				"stack": {"root", "alloy", "cache", "database", "discovery", "fargate", "network", "specta", "server"},
+				"stack": {"root", "alloy", "cache", "database", "deployment", "discovery", "fargate", "network", "specta", "server"},
 			},
 			Met: c.Met,
 			Nam: Metric,


### PR DESCRIPTION
With https://github.com/0xSplits/splits/pull/1846 we manage a new nested stack `DeploymentStack`. This PR adds it to our infrastructure status dashboard in Grafana. This change will also fix the warning logs we are seeing now ever since the new stack got deployed successfully.

```
{
    "time":"2025-06-27 11:08:05",
    "level":"warning",
    "message":"skipping instrumentation for CloudFormation stack",
    "name":"server-test-DeploymentStack-1JM2SKMO7XAMV",
    "reason":"CloudFormation stack name pattern is unrecognizable",
    "caller":"/build/pkg/worker/handler/stack/stack.go:73"
}
```