### PR TITLE
add logging for non-ok status codes

### DIFF
--- a/pkg/worker/handler/endpoint/ensure.go
+++ b/pkg/worker/handler/endpoint/ensure.go
@@ -2,6 +2,7 @@ package endpoint
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/xh3b4sd/tracer"
 )
@@ -10,14 +11,26 @@ func (h *Handler) Ensure() error {
 	var err error
 
 	for k, v := range mapping {
+		var url string
+		{
+			url = v[h.env.Environment]
+		}
+
 		var sta int
 		{
-			sta = musSta(v[h.env.Environment])
+			sta = musSta(url)
 		}
 
 		var hlt float64
 		if sta == http.StatusOK {
 			hlt = 1
+		} else {
+			h.log.Log(
+				"level", "info",
+				"message", "observed non-ok status code",
+				"url", url,
+				"code", strconv.Itoa(sta),
+			)
 		}
 
 		{

--- a/pkg/worker/handler/endpoint/handler.go
+++ b/pkg/worker/handler/endpoint/handler.go
@@ -22,10 +22,15 @@ var (
 			"staging":    "https://beta.app.splits.org",
 			"production": "https://app.splits.org",
 		},
-		"server": {
+		"fargate": {
 			"testing":    "https://test.api.splits.org/metrics",
 			"staging":    "https://beta.api.splits.org/metrics",
 			"production": "https://api.splits.org/metrics",
+		},
+		"server": {
+			"testing":    "https://server.testing.splits.org/metrics",
+			"staging":    "https://server.staging.splits.org/metrics",
+			"production": "https://server.production.splits.org/metrics",
 		},
 		"specta": {
 			"testing":    "https://specta.testing.splits.org/metrics",
@@ -68,7 +73,7 @@ func New(c Config) *Handler {
 		gau[Metric] = recorder.NewGauge(recorder.GaugeConfig{
 			Des: "the health status of an http endpoint",
 			Lab: map[string][]string{
-				"service": {"explorer", "server", "specta", "teams"},
+				"service": {"explorer", "fargate", "server", "specta", "teams"},
 			},
 			Met: c.Met,
 			Nam: Metric,


### PR DESCRIPTION
I recall conversations about an issue with load balancer responses of 502 status codes. I was wondering whether Specta ever picks up on those, because the infra status dash doesn't show this kind of flakiness. So here we just add some logging to see whether 502 is ever perceived.

I also added the endpoint checks for the new server containers in here. `fargate` are the old server containers. `server` are the new ones.

```
# HELP http_endpoint_health the health status of an http endpoint
# TYPE http_endpoint_health gauge
http_endpoint_health{env="testing",otel_scope_name="specta.testing.splits.org",otel_scope_schema_url="",otel_scope_version="n/a",service="explorer"} 1
http_endpoint_health{env="testing",otel_scope_name="specta.testing.splits.org",otel_scope_schema_url="",otel_scope_version="n/a",service="fargate"} 1
http_endpoint_health{env="testing",otel_scope_name="specta.testing.splits.org",otel_scope_schema_url="",otel_scope_version="n/a",service="server"} 1
http_endpoint_health{env="testing",otel_scope_name="specta.testing.splits.org",otel_scope_schema_url="",otel_scope_version="n/a",service="specta"} 1
http_endpoint_health{env="testing",otel_scope_name="specta.testing.splits.org",otel_scope_schema_url="",otel_scope_version="n/a",service="teams"} 1
```