### PR TITLE
update urls for staging clients

### DIFF
--- a/pkg/worker/handler/endpoint/handler.go
+++ b/pkg/worker/handler/endpoint/handler.go
@@ -19,7 +19,7 @@ var (
 	mapping = map[string]map[string]string{
 		"explorer": {
 			"testing":    "https://test.app.splits.org",
-			"staging":    "https://beta.app.splits.org",
+			"staging":    "https://dev.app.splits.org",
 			"production": "https://app.splits.org",
 		},
 		"fargate": {
@@ -39,7 +39,7 @@ var (
 		},
 		"teams": {
 			"testing":    "https://test.teams.splits.org",
-			"staging":    "https://beta.teams.splits.org",
+			"staging":    "https://dev.teams.splits.org",
 			"production": "https://teams.splits.org",
 		},
 	}


### PR DESCRIPTION
Updates the staging url's to point to the correct subdomain. Addresses the endpoint health errors on the staging environment:
<img width="697" alt="Screenshot 2025-06-30 at 10 18 29 PM" src="https://github.com/user-attachments/assets/adeb0182-7745-4d0c-98ad-3ebbf0e888a7" />

Will need to deploy to staging to see it take effect.

cc @xh3b4sd 