### PR TITLE
isolate failure domains for all worker handlers

### DIFF
--- a/pkg/daemon/worker.go
+++ b/pkg/daemon/worker.go
@@ -22,6 +22,7 @@ func (d *Daemon) Worker() *worker.Worker {
 	}
 
 	return worker.New(worker.Config{
+		Env: d.env,
 		Han: []handler.Interface{
 			container.New(container.Config{Aws: cfg, Env: d.env, Log: d.log, Met: d.met}),
 			endpoint.New(endpoint.Config{Env: d.env, Log: d.log, Met: d.met}),
@@ -29,6 +30,7 @@ func (d *Daemon) Worker() *worker.Worker {
 			stack.New(stack.Config{Aws: cfg, Env: d.env, Log: d.log, Met: d.met}),
 		},
 		Log: d.log,
+		Met: d.met,
 	})
 }
 

--- a/pkg/recorder/histogram.go
+++ b/pkg/recorder/histogram.go
@@ -9,6 +9,7 @@ import (
 )
 
 type HistogramConfig struct {
+	Buc []float64
 	Des string
 	Lab map[string][]string
 	Met metric.Meter
@@ -21,7 +22,7 @@ type Histogram struct {
 }
 
 func NewHistogram(c HistogramConfig) *Histogram {
-	his, err := c.Met.Float64Histogram(c.Nam, metric.WithDescription(c.Des))
+	his, err := c.Met.Float64Histogram(c.Nam, metric.WithDescription(c.Des), metric.WithExplicitBucketBoundaries(c.Buc...))
 	if err != nil {
 		tracer.Panic(tracer.Mask(err))
 	}

--- a/pkg/server/handler/metrics/handler.go
+++ b/pkg/server/handler/metrics/handler.go
@@ -55,10 +55,23 @@ func New(c Config) *Handler {
 
 	{
 		nam := "teams_bridge_duration_seconds"
-		cou[nam] = recorder.NewHistogram(recorder.HistogramConfig{
-			Des: "the time it takes for bridge transactions",
+		his[nam] = recorder.NewHistogram(recorder.HistogramConfig{
+			Des: "the time it takes for bridge transactions to complete",
 			Lab: map[string][]string{
 				"success": {"true", "false"},
+			},
+			Buc: []float64{
+				0.1, //     100ms
+				0.5, //     500ms
+				1.0, //   1,000ms
+				2.5, //   2,500ms
+				5.0, //   5,000ms
+
+				10.0, // 10,000ms
+				15.0, // 15,000ms
+				20.0, // 20,000ms
+				25.0, // 25,000ms
+				30.0, // 30,000ms
 			},
 			Met: c.Met,
 			Nam: nam,

--- a/pkg/worker/handler/container/cooler.go
+++ b/pkg/worker/handler/container/cooler.go
@@ -1,0 +1,9 @@
+package container
+
+import (
+	"time"
+)
+
+func (h *Handler) Cooler() time.Duration {
+	return 5 * time.Second
+}

--- a/pkg/worker/handler/endpoint/cooler.go
+++ b/pkg/worker/handler/endpoint/cooler.go
@@ -1,0 +1,9 @@
+package endpoint
+
+import (
+	"time"
+)
+
+func (h *Handler) Cooler() time.Duration {
+	return 5 * time.Second
+}

--- a/pkg/worker/handler/endpoint/ensure.go
+++ b/pkg/worker/handler/endpoint/ensure.go
@@ -12,8 +12,12 @@ func (h *Handler) Ensure() error {
 
 	for k, v := range mapping {
 		var url string
+		var exi bool
 		{
-			url = v[h.env.Environment]
+			url, exi = v[h.env.Environment]
+			if !exi {
+				continue
+			}
 		}
 
 		var sta int

--- a/pkg/worker/handler/endpoint/handler.go
+++ b/pkg/worker/handler/endpoint/handler.go
@@ -17,20 +17,18 @@ const (
 
 var (
 	mapping = map[string]map[string]string{
+		"api": {
+			"production": "https://api.splits.org/metrics",
+		},
 		"explorer": {
 			"testing":    "https://test.app.splits.org",
 			"staging":    "https://dev.app.splits.org",
 			"production": "https://app.splits.org",
 		},
-		"fargate": {
-			"testing":    "https://test.api.splits.org/metrics",
-			"staging":    "https://beta.api.splits.org/metrics",
-			"production": "https://api.splits.org/metrics",
-		},
 		"server": {
 			"testing":    "https://server.testing.splits.org/metrics",
 			"staging":    "https://server.staging.splits.org/metrics",
-			"production": "https://server.production.splits.org/metrics",
+			"production": "https://server.production.splits.org/metrics", // api.splits.org
 		},
 		"specta": {
 			"testing":    "https://specta.testing.splits.org/metrics",
@@ -73,7 +71,7 @@ func New(c Config) *Handler {
 		gau[Metric] = recorder.NewGauge(recorder.GaugeConfig{
 			Des: "the health status of an http endpoint",
 			Lab: map[string][]string{
-				"service": {"explorer", "fargate", "server", "specta", "teams"},
+				"service": {"api", "explorer", "server", "specta", "teams"},
 			},
 			Met: c.Met,
 			Nam: Metric,

--- a/pkg/worker/handler/interface.go
+++ b/pkg/worker/handler/interface.go
@@ -1,7 +1,17 @@
 package handler
 
+import "time"
+
 type Interface interface {
+	// Cooler is the amount of time that any given handler specifies to wait
+	// before being executed again. This is not an interval on a strict schedule.
+	// This is simply the time to sleep after execution, before another cycle
+	// repeats.
+	Cooler() time.Duration
+
 	// Ensure executes the handler specific business logic in order to complete
-	// the given task, if possible.
+	// the given task, if possible. Any error returned will be emitted using the
+	// underlying logger interface. Calling this method will not interfere with
+	// the execution of other handlers.
 	Ensure() error
 }

--- a/pkg/worker/handler/keypair/cooler.go
+++ b/pkg/worker/handler/keypair/cooler.go
@@ -1,0 +1,9 @@
+package keypair
+
+import (
+	"time"
+)
+
+func (h *Handler) Cooler() time.Duration {
+	return 5 * time.Second
+}

--- a/pkg/worker/handler/name.go
+++ b/pkg/worker/handler/name.go
@@ -1,0 +1,35 @@
+package handler
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Name returns the package declaration of the given handler implementation.
+func Name(h Interface) string {
+	//
+	//     *keypair.Handler
+	//
+	var p string
+	{
+		p = fmt.Sprintf("%T", h)
+	}
+
+	//
+	//     keypair.Handler
+	//
+	var t string
+	{
+		t = strings.TrimPrefix(p, "*")
+	}
+
+	//
+	//     keypair
+	//
+	var s string
+	{
+		s = strings.Split(t, ".")[0]
+	}
+
+	return s
+}

--- a/pkg/worker/handler/name_test.go
+++ b/pkg/worker/handler/name_test.go
@@ -1,0 +1,57 @@
+package handler
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/0xSplits/specta/pkg/worker/handler/container"
+	"github.com/0xSplits/specta/pkg/worker/handler/keypair"
+)
+
+func Test_Worker_Handler_Name(t *testing.T) {
+	testCases := []struct {
+		han Interface
+		nam string
+	}{
+		// Case 000
+		{
+			han: &testHandler{},
+			nam: "handler",
+		},
+		// Case 001
+		{
+			han: (*testHandler)(nil),
+			nam: "handler",
+		},
+		// Case 002
+		{
+			han: &container.Handler{},
+			nam: "container",
+		},
+		// Case 003
+		{
+			han: &keypair.Handler{},
+			nam: "keypair",
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%03d", i), func(t *testing.T) {
+			nam := Name(tc.han)
+			if nam != tc.nam {
+				t.Fatalf("expected %#v got %#v", tc.nam, nam)
+			}
+		})
+	}
+}
+
+type testHandler struct{}
+
+func (h *testHandler) Cooler() time.Duration {
+	return 0
+}
+
+func (h *testHandler) Ensure() error {
+	return nil
+}

--- a/pkg/worker/handler/stack/cooler.go
+++ b/pkg/worker/handler/stack/cooler.go
@@ -1,0 +1,9 @@
+package stack
+
+import (
+	"time"
+)
+
+func (h *Handler) Cooler() time.Duration {
+	return 5 * time.Second
+}

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -2,23 +2,36 @@ package worker
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
+	"github.com/0xSplits/specta/pkg/envvar"
+	"github.com/0xSplits/specta/pkg/recorder"
+	"github.com/0xSplits/specta/pkg/registry"
 	"github.com/0xSplits/specta/pkg/worker/handler"
 	"github.com/xh3b4sd/logger"
 	"github.com/xh3b4sd/tracer"
+	"go.opentelemetry.io/otel/metric"
+)
+
+const (
+	MetricTotal    = "worker_handler_execution_total"
+	MetricDuration = "worker_handler_execution_duration_seconds"
 )
 
 type Config struct {
+	Env envvar.Env
 	// Han are the worker specific handlers implementing the actual business
 	// logic.
 	Han []handler.Interface
 	Log logger.Interface
+	Met metric.Meter
 }
 
 type Worker struct {
 	han []handler.Interface
 	log logger.Interface
+	reg registry.Interface
 }
 
 func New(c Config) *Worker {
@@ -28,10 +41,70 @@ func New(c Config) *Worker {
 	if c.Log == nil {
 		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Log must not be empty", c)))
 	}
+	if c.Met == nil {
+		tracer.Panic(tracer.Mask(fmt.Errorf("%T.Met must not be empty", c)))
+	}
+
+	cou := map[string]recorder.Interface{}
+
+	{
+		cou[MetricTotal] = recorder.NewCounter(recorder.CounterConfig{
+			Des: "the total amount of worker handler executions",
+			Lab: map[string][]string{
+				"service": {"specta"},
+				"success": {"true", "false"},
+			},
+			Met: c.Met,
+			Nam: MetricTotal,
+		})
+	}
+
+	gau := map[string]recorder.Interface{}
+
+	his := map[string]recorder.Interface{}
+
+	{
+		his[MetricDuration] = recorder.NewHistogram(recorder.HistogramConfig{
+			Des: "the time it takes for worker handler executions to complete",
+			Lab: map[string][]string{
+				"handler": {"container", "endpoint", "keypair", "stack"},
+				"service": {"specta"},
+				"success": {"true", "false"},
+			},
+			Buc: []float64{
+				0.05, //   50 ms
+				0.10, //  100 ms
+				0.15, //  150 ms
+				0.20, //  200 ms
+				0.25, //  250 ms
+
+				0.50, //  500 ms
+				1.00, // 1000 ms
+				1.50, // 1500 ms
+				2.00, // 2000 ms
+				2.50, // 2500 ms
+			},
+			Met: c.Met,
+			Nam: MetricDuration,
+		})
+	}
+
+	var reg registry.Interface
+	{
+		reg = registry.New(registry.Config{
+			Env: c.Env,
+			Log: c.Log,
+
+			Cou: cou,
+			Gau: gau,
+			His: his,
+		})
+	}
 
 	return &Worker{
 		han: c.Han,
 		log: c.Log,
+		reg: reg,
 	}
 }
 
@@ -41,20 +114,114 @@ func (w *Worker) Daemon() {
 		"message", "worker is executing tasks",
 	)
 
+	// Bootstrap a static worker pool of N goroutines, where N is the number of
+	// injected worker handlers. This parallel execution isolates worker specific
+	// failure domains. Each handler is executed along its own pipeline so that
+	// any handler specific runtime errors and execution delays cannot affect the
+	// execution of the other worker handlers.
+
+	for _, h := range w.han {
+		go w.daemon(h)
+	}
+
+	// Once the static worker pool created all necessary goroutines, we block
+	// Worker.Daemon forever as a long running process, so that we do not risk
+	// terminating the goroutines that we just bootstrapped.
+
+	{
+		select {}
+	}
+}
+
+func (w *Worker) daemon(han handler.Interface) {
 	for {
-		for _, h := range w.han {
-			err := h.Ensure()
-			if err != nil {
-				w.log.Log(
-					"level", "error",
-					"message", err.Error(),
-					"stack", tracer.Stack(err),
-				)
-			}
+		err := w.ensure(han)
+		if err != nil {
+			w.error(err)
 		}
 
+		// Sleep for the given duration after this worker handler has been executed.
+		// This specific cycle repeats again for the given worker handler only,
+		// after the sleep below is over.
+
 		{
-			time.Sleep(5 * time.Second)
+			time.Sleep(han.Cooler())
 		}
 	}
+}
+
+func (w *Worker) ensure(han handler.Interface) error {
+	// Record the start time for our handler latency. The timezone of the duration
+	// measurement is irrelavant here, so we are not using time.Now().UTC() as a
+	// best practice like we would in other places.
+
+	var sta time.Time
+	{
+		sta = time.Now()
+	}
+
+	// Note that we cannot return the error from the handler execution, because we
+	// want to monitor the failure latency as well, if possible. So instead of
+	// returning the error early during the error case, we simply log the error
+	// and continue below.
+
+	var err error
+	{
+		err = han.Ensure()
+		if err != nil {
+			w.error(err)
+		}
+	}
+
+	// Record the handler latency immediately after the handler execution. Here as
+	// well, time.Since() does not rely on a specific timezone, so we can simply
+	// use the time.Now() instance of this cycle's start time.
+
+	var lat time.Duration
+	{
+		lat = time.Since(sta)
+	}
+
+	w.log.Log(
+		"level", "debug",
+		"message", "executed worker handler",
+		"handler", handler.Name(han),
+		"latency", lat.String(),
+		"success", strconv.FormatBool(err == nil),
+	)
+
+	{
+		lab := map[string]string{
+			"service": "specta",
+			"success": strconv.FormatBool(err == nil),
+		}
+
+		err := w.reg.Counter(MetricTotal, 1, lab)
+		if err != nil {
+			return tracer.Mask(err)
+		}
+	}
+
+	{
+		lab := map[string]string{
+			"handler": handler.Name(han),
+			"service": "specta",
+			"success": strconv.FormatBool(err == nil),
+		}
+
+		err := w.reg.Histogram(MetricDuration, lat.Seconds(), lab)
+		if err != nil {
+			return tracer.Mask(err)
+		}
+	}
+
+	return nil
+}
+
+func (w *Worker) error(err error) {
+	w.log.Log(
+		"level", "error",
+		"message", err.Error(),
+		"stack", tracer.Stack(err),
+	)
 }

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -72,17 +72,17 @@ func New(c Config) *Worker {
 				"success": {"true", "false"},
 			},
 			Buc: []float64{
-				0.05, //   50 ms
 				0.10, //  100 ms
 				0.15, //  150 ms
 				0.20, //  200 ms
 				0.25, //  250 ms
-
 				0.50, //  500 ms
+
 				1.00, // 1000 ms
 				1.50, // 1500 ms
 				2.00, // 2000 ms
 				2.50, // 2500 ms
+				5.00, // 5000 ms
 			},
 			Met: c.Met,
 			Nam: MetricDuration,

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -1,0 +1,119 @@
+package worker
+
+import (
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/0xSplits/specta/pkg/envvar"
+	"github.com/0xSplits/specta/pkg/recorder"
+	"github.com/0xSplits/specta/pkg/runtime"
+	"github.com/0xSplits/specta/pkg/worker/handler"
+	"github.com/xh3b4sd/logger"
+)
+
+func Test_Worker_handler_execution(t *testing.T) {
+	var in1 chan string
+	var in2 chan string
+	var out chan string
+	{
+		in1 = make(chan string, 1)
+		in2 = make(chan string, 3)
+		out = make(chan string, 6)
+	}
+
+	var wrk *Worker
+	{
+		wrk = New(Config{
+			Env: envvar.Env{Environment: "testing"},
+			Han: []handler.Interface{
+				&testHandler{inp: in1, out: out, coo: time.Hour},
+				&testHandler{inp: in2, out: out, coo: 0},
+			},
+			Log: logger.Fake(),
+			Met: recorder.NewMeter(recorder.MeterConfig{
+				Env: "testing",
+				Ver: runtime.Tag(),
+			}),
+		})
+	}
+
+	{
+		go wrk.Daemon()
+	}
+
+	{
+		time.Sleep(time.Millisecond)
+	}
+
+	go func() {
+		in1 <- "one"
+		in1 <- "one"
+		in1 <- "one"
+	}()
+
+	go func() {
+		in2 <- "two"
+		in2 <- "two"
+		in2 <- "two"
+	}()
+
+	var exp []string
+	{
+		exp = []string{
+			"one",
+
+			"two",
+			"two",
+			"two",
+		}
+	}
+
+	var act []string
+	for x := range out {
+		{
+			act = append(act, x)
+		}
+
+		if len(act) == len(exp) {
+			close(out)
+		}
+	}
+
+	select {
+	case <-out:
+		{
+			slices.Sort(act)
+			slices.Sort(exp)
+		}
+
+		if !slices.Equal(act, exp) {
+			t.Fatalf("expected %#v got %#v", exp, act)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("test timeout")
+	}
+}
+
+type testHandler struct {
+	coo time.Duration
+	inp chan string
+	out chan string
+}
+
+func (h *testHandler) Cooler() time.Duration {
+	return h.coo
+}
+
+func (h *testHandler) Ensure() error {
+	var s string
+	{
+		s = <-h.inp
+	}
+
+	{
+		h.out <- s
+	}
+
+	return nil
+}


### PR DESCRIPTION
In preparation for instrumenting our deployment pipelines, I recognized that we need to run worker handlers in different intervals, because it does not make a lot of sense to look for data that is changing rather infrequently. E.g. the health of an HTTP endpoint may change any moment, so we check its status every 5 seconds. But there might be hours in our current situation were the metrics of our deployment pipelines do not change, simply because no code change is being pushed nor rolled out for extended periods of time. In such cases we may want to check for data rather infrequently, e.g. only every minute.

This PR enables every worker handler therefore to define its own interval dynamics. While I was testing certain error cases, I noticed that the initial naive scheduling that we did caused other workers to not be executed anymore, if only a single random worker handler stalls, which may happen due to network errors or builtin retry behaviour as it is the case with all things AWS. So I also reworked how worker handlers are scheduled. We are not running worker handlers naively in sequence anymore. Instead, every worker handler runs within its own goroutine now, completely independent from all other worker handlers.

Additionally, we are adding some more observability about Specta's task scheduling, so that we can monitor task latency and failure rates.

```
# HELP worker_handler_execution_total the total amount of worker handler executions
# TYPE worker_handler_execution_total counter
worker_handler_execution_total{env="testing",otel_scope_name="specta.testing.splits.org",otel_scope_schema_url="",otel_scope_version="n/a",service="specta",success="true"} 88
```

```
# HELP worker_handler_execution_duration_seconds the time it takes for worker handler executions to complete
# TYPE worker_handler_execution_duration_seconds histogram
worker_handler_execution_duration_seconds_bucket{env="testing",handler="container",otel_scope_name="specta.testing.splits.org",otel_scope_schema_url="",otel_scope_version="n/a",service="specta",success="true",le="0.1"} 0
worker_handler_execution_duration_seconds_bucket{env="testing",handler="container",otel_scope_name="specta.testing.splits.org",otel_scope_schema_url="",otel_scope_version="n/a",service="specta",success="true",le="0.15"} 0
worker_handler_execution_duration_seconds_bucket{env="testing",handler="container",otel_scope_name="specta.testing.splits.org",otel_scope_schema_url="",otel_scope_version="n/a",service="specta",success="true",le="0.2"} 0
worker_handler_execution_duration_seconds_bucket{env="testing",handler="container",otel_scope_name="specta.testing.splits.org",otel_scope_schema_url="",otel_scope_version="n/a",service="specta",success="true",le="0.25"} 0
worker_handler_execution_duration_seconds_bucket{env="testing",handler="container",otel_scope_name="specta.testing.splits.org",otel_scope_schema_url="",otel_scope_version="n/a",service="specta",success="true",le="0.5"} 0
worker_handler_execution_duration_seconds_bucket{env="testing",handler="container",otel_scope_name="specta.testing.splits.org",otel_scope_schema_url="",otel_scope_version="n/a",service="specta",success="true",le="1"} 0
worker_handler_execution_duration_seconds_bucket{env="testing",handler="container",otel_scope_name="specta.testing.splits.org",otel_scope_schema_url="",otel_scope_version="n/a",service="specta",success="true",le="1.5"} 0
worker_handler_execution_duration_seconds_bucket{env="testing",handler="container",otel_scope_name="specta.testing.splits.org",otel_scope_schema_url="",otel_scope_version="n/a",service="specta",success="true",le="2"} 0
worker_handler_execution_duration_seconds_bucket{env="testing",handler="container",otel_scope_name="specta.testing.splits.org",otel_scope_schema_url="",otel_scope_version="n/a",service="specta",success="true",le="2.5"} 16
worker_handler_execution_duration_seconds_bucket{env="testing",handler="container",otel_scope_name="specta.testing.splits.org",otel_scope_schema_url="",otel_scope_version="n/a",service="specta",success="true",le="5"} 17
worker_handler_execution_duration_seconds_bucket{env="testing",handler="container",otel_scope_name="specta.testing.splits.org",otel_scope_schema_url="",otel_scope_version="n/a",service="specta",success="true",le="+Inf"} 18
worker_handler_execution_duration_seconds_sum{env="testing",handler="container",otel_scope_name="specta.testing.splits.org",otel_scope_schema_url="",otel_scope_version="n/a",service="specta",success="true"} 43.925809373
worker_handler_execution_duration_seconds_count{env="testing",handler="container",otel_scope_name="specta.testing.splits.org",otel_scope_schema_url="",otel_scope_version="n/a",service="specta",success="true"} 18
```