### PR TITLE
whitelist page ready histogram for frontend slo

### DIFF
--- a/pkg/server/handler/metrics/handler.go
+++ b/pkg/server/handler/metrics/handler.go
@@ -33,45 +33,29 @@ func New(c Config) *Handler {
 
 	cou := map[string]recorder.Interface{}
 
-	{
-		nam := "teams_bridge_total"
-		cou[nam] = recorder.NewCounter(recorder.CounterConfig{
-			Des: "the total amount of bridge transactions",
-			Lab: map[string][]string{
-				"success": {"true", "false"},
-			},
-			Met: c.Met,
-			Nam: nam,
-		})
-	}
-
 	gau := map[string]recorder.Interface{}
-
-	{
-		// gauges can be registered here
-	}
 
 	his := map[string]recorder.Interface{}
 
 	{
-		nam := "teams_bridge_duration_seconds"
+		nam := "page_ready_duration_seconds"
 		his[nam] = recorder.NewHistogram(recorder.HistogramConfig{
-			Des: "the time it takes for bridge transactions to complete",
+			Des: "the time it takes for the app to show a page",
 			Lab: map[string][]string{
-				"success": {"true", "false"},
+				"page": {"root"},
 			},
 			Buc: []float64{
-				0.1, //     100ms
-				0.5, //     500ms
-				1.0, //   1,000ms
-				2.5, //   2,500ms
-				5.0, //   5,000ms
+				0.1, //   100ms
+				0.2, //   200ms
+				0.3, //   300ms
+				0.4, //   400ms
+				0.5, //   500ms
 
-				10.0, // 10,000ms
-				15.0, // 15,000ms
-				20.0, // 20,000ms
-				25.0, // 25,000ms
-				30.0, // 30,000ms
+				1.0, // 1,000ms
+				2.0, // 2,000ms
+				3.0, // 3,000ms
+				4.0, // 4,000ms
+				5.0, // 5,000ms
 			},
 			Met: c.Met,
 			Nam: nam,

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -51,7 +51,6 @@ func New(c Config) *Worker {
 		cou[MetricTotal] = recorder.NewCounter(recorder.CounterConfig{
 			Des: "the total amount of worker handler executions",
 			Lab: map[string][]string{
-				"service": {"specta"},
 				"success": {"true", "false"},
 			},
 			Met: c.Met,
@@ -68,7 +67,6 @@ func New(c Config) *Worker {
 			Des: "the time it takes for worker handler executions to complete",
 			Lab: map[string][]string{
 				"handler": {"container", "endpoint", "keypair", "stack"},
-				"service": {"specta"},
 				"success": {"true", "false"},
 			},
 			Buc: []float64{
@@ -178,8 +176,10 @@ func (w *Worker) ensure(han handler.Interface) error {
 	// use the time.Now() instance of this cycle's start time.
 
 	var lat time.Duration
+	var suc string
 	{
 		lat = time.Since(sta)
+		suc = strconv.FormatBool(err == nil)
 	}
 
 	w.log.Log(
@@ -187,13 +187,12 @@ func (w *Worker) ensure(han handler.Interface) error {
 		"message", "executed worker handler",
 		"handler", handler.Name(han),
 		"latency", lat.String(),
-		"success", strconv.FormatBool(err == nil),
+		"success", suc,
 	)
 
 	{
 		lab := map[string]string{
-			"service": "specta",
-			"success": strconv.FormatBool(err == nil),
+			"success": suc,
 		}
 
 		err := w.reg.Counter(MetricTotal, 1, lab)
@@ -205,8 +204,7 @@ func (w *Worker) ensure(han handler.Interface) error {
 	{
 		lab := map[string]string{
 			"handler": handler.Name(han),
-			"service": "specta",
-			"success": strconv.FormatBool(err == nil),
+			"success": suc,
 		}
 
 		err := w.reg.Histogram(MetricDuration, lat.Seconds(), lab)


### PR DESCRIPTION
Chatting with @oponder we figured how to start instrumenting our first frontend SLO use case. We noticed that the main pages take a long time to load properly before being ready for the user. So here we are defining `page_ready_duration_seconds` as a histogram in order to track the readiness latency of the frontend in some major cases. 