### PR TITLE
set client endpoints to new url scheme

### DIFF
--- a/pkg/worker/handler/container/handler.go
+++ b/pkg/worker/handler/container/handler.go
@@ -52,7 +52,7 @@ func New(c Config) *Handler {
 		gau[Metric] = recorder.NewGauge(recorder.GaugeConfig{
 			Des: "the health status of ecs service containers",
 			Lab: map[string][]string{
-				"service": {"alloy", "fargate", "graphql", "otel-collector", "server", "specta", "worker"},
+				"service": {"alloy", "graphql", "otel-collector", "server", "specta", "worker"},
 			},
 			Met: c.Met,
 			Nam: Metric,

--- a/pkg/worker/handler/endpoint/ensure.go
+++ b/pkg/worker/handler/endpoint/ensure.go
@@ -11,36 +11,29 @@ func (h *Handler) Ensure() error {
 	var err error
 
 	for k, v := range mapping {
-		var url string
-		var exi bool
-		{
-			url, exi = v[h.env.Environment]
-			if !exi {
-				continue
+		for _, x := range v[h.env.Environment] {
+			var sta int
+			{
+				sta = musSta(x)
 			}
-		}
 
-		var sta int
-		{
-			sta = musSta(url)
-		}
+			var hlt float64
+			if sta == http.StatusOK {
+				hlt = 1
+			} else {
+				h.log.Log(
+					"level", "info",
+					"message", "observed non-ok status code",
+					"url", x,
+					"code", strconv.Itoa(sta),
+				)
+			}
 
-		var hlt float64
-		if sta == http.StatusOK {
-			hlt = 1
-		} else {
-			h.log.Log(
-				"level", "info",
-				"message", "observed non-ok status code",
-				"url", url,
-				"code", strconv.Itoa(sta),
-			)
-		}
-
-		{
-			err = h.reg.Gauge(Metric, hlt, map[string]string{"service": k})
-			if err != nil {
-				return tracer.Mask(err)
+			{
+				err = h.reg.Gauge(Metric, hlt, map[string]string{"service": k})
+				if err != nil {
+					return tracer.Mask(err)
+				}
 			}
 		}
 	}

--- a/pkg/worker/handler/endpoint/handler.go
+++ b/pkg/worker/handler/endpoint/handler.go
@@ -16,29 +16,26 @@ const (
 )
 
 var (
-	mapping = map[string]map[string]string{
-		"api": {
-			"production": "https://api.splits.org/metrics",
-		},
+	mapping = map[string]map[string][]string{
 		"explorer": {
-			"testing":    "https://test.app.splits.org",
-			"staging":    "https://dev.app.splits.org",
-			"production": "https://app.splits.org",
+			"testing":    {"https://explorer.testing.splits.org"},
+			"staging":    {"https://explorer.staging.splits.org"},
+			"production": {"https://explorer.production.splits.org", "https://app.splits.org"},
 		},
 		"server": {
-			"testing":    "https://server.testing.splits.org/metrics",
-			"staging":    "https://server.staging.splits.org/metrics",
-			"production": "https://server.production.splits.org/metrics", // api.splits.org
+			"testing":    {"https://server.testing.splits.org/metrics"},
+			"staging":    {"https://server.staging.splits.org/metrics"},
+			"production": {"https://server.production.splits.org/metrics", "api.splits.org"},
 		},
 		"specta": {
-			"testing":    "https://specta.testing.splits.org/metrics",
-			"staging":    "https://specta.staging.splits.org/metrics",
-			"production": "https://specta.production.splits.org/metrics",
+			"testing":    {"https://specta.testing.splits.org/metrics"},
+			"staging":    {"https://specta.staging.splits.org/metrics"},
+			"production": {"https://specta.production.splits.org/metrics"},
 		},
 		"teams": {
-			"testing":    "https://test.teams.splits.org",
-			"staging":    "https://dev.teams.splits.org",
-			"production": "https://teams.splits.org",
+			"testing":    {"https://teams.testing.splits.org"},
+			"staging":    {"https://teams.staging.splits.org"},
+			"production": {"https://teams.production.splits.org", "https://teams.splits.org"},
 		},
 	}
 )
@@ -71,7 +68,7 @@ func New(c Config) *Handler {
 		gau[Metric] = recorder.NewGauge(recorder.GaugeConfig{
 			Des: "the health status of an http endpoint",
 			Lab: map[string][]string{
-				"service": {"api", "explorer", "server", "specta", "teams"},
+				"service": {"explorer", "server", "specta", "teams"},
 			},
 			Met: c.Met,
 			Nam: Metric,


### PR DESCRIPTION
Since our frontends are configured to run on the new DNS record scheme, we saw that the Explorer and Teams were reported to be down in our infrastructure status dashboard for the `testing` and `staging` environments because we removed the old DNS records, causing those checks to fail.

Here we are setting the new DNS records inside the `endpoint` worker handler for those checks to succeed again in the infrastructure status dashboard.