### PR TITLE
fix cname url for api server

### DIFF
--- a/pkg/worker/handler/endpoint/handler.go
+++ b/pkg/worker/handler/endpoint/handler.go
@@ -25,7 +25,7 @@ var (
 		"server": {
 			"testing":    {"https://server.testing.splits.org/metrics"},
 			"staging":    {"https://server.staging.splits.org/metrics"},
-			"production": {"https://server.production.splits.org/metrics", "api.splits.org"},
+			"production": {"https://server.production.splits.org/metrics", "https://api.splits.org/metrics"},
 		},
 		"specta": {
 			"testing":    {"https://specta.testing.splits.org/metrics"},


### PR DESCRIPTION
We had the API CNAME misconfigured, causing the infrastructure status dashboard to report the API Server to be down. The API Server is not down, Specta is simply using the wrong endpoint to verify.

<img width="732" height="350" alt="Screenshot 2025-07-18 at 15 09 25" src="https://github.com/user-attachments/assets/9da1b82a-11c8-49e6-a457-ea8fae9ba820" />
