### PR TITLE
run container handler internals concurrently

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/rs/cors v1.11.1
 	github.com/spf13/cobra v1.9.1
 	github.com/twitchtv/twirp v8.1.3+incompatible
+	github.com/xh3b4sd/choreo v0.1.0
 	github.com/xh3b4sd/logger v0.11.0
 	github.com/xh3b4sd/tracer v1.0.0
 	go.opentelemetry.io/otel/metric v1.37.0
@@ -58,6 +59,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.37.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.37.0 // indirect
 	go.opentelemetry.io/otel/trace v1.37.0 // indirect
+	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/sys v0.34.0 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/rs/cors v1.11.1
 	github.com/spf13/cobra v1.9.1
 	github.com/twitchtv/twirp v8.1.3+incompatible
-	github.com/xh3b4sd/choreo v0.1.0
+	github.com/xh3b4sd/choreo v0.1.1
 	github.com/xh3b4sd/logger v0.11.0
 	github.com/xh3b4sd/tracer v1.0.0
 	go.opentelemetry.io/otel/metric v1.37.0

--- a/go.sum
+++ b/go.sum
@@ -103,6 +103,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/twitchtv/twirp v8.1.3+incompatible h1:+F4TdErPgSUbMZMwp13Q/KgDVuI7HJXP61mNV3/7iuU=
 github.com/twitchtv/twirp v8.1.3+incompatible/go.mod h1:RRJoFSAmTEh2weEqWtpPE3vFK5YBhA6bqp2l1kfCC5A=
+github.com/xh3b4sd/choreo v0.1.0 h1:vxBEPCPODRoQctxVbqkLdMpYilt1W8LZUnKvNqIjNF4=
+github.com/xh3b4sd/choreo v0.1.0/go.mod h1:8m/uJZo3+QjdghB9yslXz9+JjOt80omyUGhYx2x185Y=
 github.com/xh3b4sd/logger v0.11.0 h1:ia51supeLKtmF3YihRCI4o+pN+IkTiRK0QmY/KbWUjs=
 github.com/xh3b4sd/logger v0.11.0/go.mod h1:MC7Dp7RC3tZ182KlvSulGcRQVX/D2l+WlCSGLF1mvO8=
 github.com/xh3b4sd/tracer v1.0.0 h1:mr9uYCx/Ry2w1wdJz0V0Kq71/KeF+hUQjbZQJCxm3Zw=
@@ -121,6 +123,8 @@ go.opentelemetry.io/otel/sdk/metric v1.37.0 h1:90lI228XrB9jCMuSdA0673aubgRobVZFh
 go.opentelemetry.io/otel/sdk/metric v1.37.0/go.mod h1:cNen4ZWfiD37l5NhS+Keb5RXVWZWpRE+9WyVCpbo5ps=
 go.opentelemetry.io/otel/trace v1.37.0 h1:HLdcFNbRQBE2imdSEgm/kwqmQj1Or1l/7bW6mxVK7z4=
 go.opentelemetry.io/otel/trace v1.37.0/go.mod h1:TlgrlQ+PtQO5XFerSPUYG0JSgGyryXewPGyayAWSBS0=
+golang.org/x/sync v0.16.0 h1:ycBJEhp9p4vXvUZNszeOq0kGTPghopOL8q0fq3vstxw=
+golang.org/x/sync v0.16.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.34.0 h1:H5Y5sJ2L2JRdyv7ROF1he/lPdvFsd0mJHFw2ThKHxLA=
 golang.org/x/sys v0.34.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/twitchtv/twirp v8.1.3+incompatible h1:+F4TdErPgSUbMZMwp13Q/KgDVuI7HJXP61mNV3/7iuU=
 github.com/twitchtv/twirp v8.1.3+incompatible/go.mod h1:RRJoFSAmTEh2weEqWtpPE3vFK5YBhA6bqp2l1kfCC5A=
-github.com/xh3b4sd/choreo v0.1.0 h1:vxBEPCPODRoQctxVbqkLdMpYilt1W8LZUnKvNqIjNF4=
-github.com/xh3b4sd/choreo v0.1.0/go.mod h1:8m/uJZo3+QjdghB9yslXz9+JjOt80omyUGhYx2x185Y=
+github.com/xh3b4sd/choreo v0.1.1 h1:oHJB76koJ8RPAKudxJjzIzAlmUYgHKfS3JMmdn1SXdY=
+github.com/xh3b4sd/choreo v0.1.1/go.mod h1:8m/uJZo3+QjdghB9yslXz9+JjOt80omyUGhYx2x185Y=
 github.com/xh3b4sd/logger v0.11.0 h1:ia51supeLKtmF3YihRCI4o+pN+IkTiRK0QmY/KbWUjs=
 github.com/xh3b4sd/logger v0.11.0/go.mod h1:MC7Dp7RC3tZ182KlvSulGcRQVX/D2l+WlCSGLF1mvO8=
 github.com/xh3b4sd/tracer v1.0.0 h1:mr9uYCx/Ry2w1wdJz0V0Kq71/KeF+hUQjbZQJCxm3Zw=

--- a/pkg/worker/handler/container/service.go
+++ b/pkg/worker/handler/container/service.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
-	prallel "github.com/xh3b4sd/choreo/parallel"
+	"github.com/xh3b4sd/choreo/parallel"
 	"github.com/xh3b4sd/tracer"
 )
 
@@ -51,7 +51,7 @@ func (h *Handler) service(det []detail) ([]service, error) {
 	}
 
 	{
-		err = prallel.Slice(det, fnc) // TODO fix package name
+		err = parallel.Slice(det, fnc)
 		if err != nil {
 			return nil, tracer.Mask(err)
 		}

--- a/pkg/worker/handler/container/service.go
+++ b/pkg/worker/handler/container/service.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	prallel "github.com/xh3b4sd/choreo/parallel"
 	"github.com/xh3b4sd/tracer"
 )
 
@@ -21,10 +22,10 @@ type service struct {
 // all services that have all of their desired containers running. Otherwise the
 // unhealthy status 0 is assigned.
 func (h *Handler) service(det []detail) ([]service, error) {
+	var ser []service
 	var err error
 
-	var ser []service
-	for _, x := range det {
+	fnc := func(_ int, x detail) error {
 		var inp *ecs.DescribeServicesInput
 		{
 			inp = &ecs.DescribeServicesInput{
@@ -38,48 +39,65 @@ func (h *Handler) service(det []detail) ([]service, error) {
 		{
 			out, err = h.ecs.DescribeServices(context.Background(), inp)
 			if err != nil {
-				return nil, tracer.Mask(err)
+				return tracer.Mask(err)
 			}
 		}
 
-		for _, y := range out.Services {
-			var tag string
-			{
-				tag = serTag(y.Tags)
-			}
+		{
+			ser = h.append(ser, out)
+		}
 
-			if tag == "" {
-				h.log.Log(
-					"level", "warning",
-					"message", "skipping instrumentation for ECS service",
-					"reason", "ECS service has no 'service' tag",
-					"cluster", *y.ClusterArn,
-					"service", *y.ServiceArn,
-				)
+		return nil
+	}
 
-				{
-					continue
-				}
-			}
-
-			var hlt float64
-			switch {
-			case y.RunningCount == 0:
-				hlt = 0 // no containers running
-			case y.RunningCount != y.DesiredCount:
-				hlt = 0.5 // not enough containers running
-			default:
-				hlt = 1 // all containers running
-			}
-
-			ser = append(ser, service{
-				hlt: hlt,
-				lab: tag,
-			})
+	{
+		err = prallel.Slice(det, fnc) // TODO fix package name
+		if err != nil {
+			return nil, tracer.Mask(err)
 		}
 	}
 
 	return ser, nil
+}
+
+func (h *Handler) append(ser []service, out *ecs.DescribeServicesOutput) []service {
+	for _, y := range out.Services {
+		var tag string
+		{
+			tag = serTag(y.Tags)
+		}
+
+		if tag == "" {
+			h.log.Log(
+				"level", "warning",
+				"message", "skipping instrumentation for ECS service",
+				"reason", "ECS service has no 'service' tag",
+				"cluster", *y.ClusterArn,
+				"service", *y.ServiceArn,
+			)
+
+			{
+				continue
+			}
+		}
+
+		var hlt float64
+		switch {
+		case y.RunningCount == 0:
+			hlt = 0 // no containers running
+		case y.RunningCount != y.DesiredCount:
+			hlt = 0.5 // not enough containers running
+		default:
+			hlt = 1 // all containers running
+		}
+
+		ser = append(ser, service{
+			hlt: hlt,
+			lab: tag,
+		})
+	}
+
+	return ser
 }
 
 func serTag(tag []types.Tag) string {

--- a/pkg/worker/handler/deployment/pipeline.go
+++ b/pkg/worker/handler/deployment/pipeline.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/codepipeline"
 	"github.com/aws/aws-sdk-go-v2/service/codepipeline/types"
-	prallel "github.com/xh3b4sd/choreo/parallel"
+	"github.com/xh3b4sd/choreo/parallel"
 	"github.com/xh3b4sd/tracer"
 )
 
@@ -57,15 +57,15 @@ func (h *Handler) pipeline(det []detail) ([]pipeline, error) {
 			}
 		}
 
-		for _, y := range out.PipelineExecutionSummaries {
-			pip = h.append(pip, y)
+		for _, x := range out.PipelineExecutionSummaries {
+			pip = h.append(pip, x)
 		}
 
 		return nil
 	}
 
 	{
-		err = prallel.Slice(det, fnc) // TODO fix package name
+		err = parallel.Slice(det, fnc)
 		if err != nil {
 			return nil, tracer.Mask(err)
 		}

--- a/pkg/worker/handler/deployment/pipeline.go
+++ b/pkg/worker/handler/deployment/pipeline.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/codepipeline"
 	"github.com/aws/aws-sdk-go-v2/service/codepipeline/types"
+	prallel "github.com/xh3b4sd/choreo/parallel"
 	"github.com/xh3b4sd/tracer"
 )
 
@@ -36,15 +37,15 @@ type pipeline struct {
 // approach we prefer to rather miss a measurement than counting it twice,
 // because counting twice creates inconsistencies in our SLOs.
 func (h *Handler) pipeline(det []detail) ([]pipeline, error) {
+	var pip []pipeline
 	var err error
 
-	var pip []pipeline
-	for _, x := range det {
+	fnc := func(_ int, d detail) error {
 		var inp *codepipeline.ListPipelineExecutionsInput
 		{
 			inp = &codepipeline.ListPipelineExecutionsInput{
 				MaxResults:   aws.Int32(max),
-				PipelineName: aws.String(x.nam),
+				PipelineName: aws.String(d.nam),
 			}
 		}
 
@@ -52,12 +53,21 @@ func (h *Handler) pipeline(det []detail) ([]pipeline, error) {
 		{
 			out, err = h.acp.ListPipelineExecutions(context.Background(), inp)
 			if err != nil {
-				return nil, tracer.Mask(err)
+				return tracer.Mask(err)
 			}
 		}
 
 		for _, y := range out.PipelineExecutionSummaries {
 			pip = h.append(pip, y)
+		}
+
+		return nil
+	}
+
+	{
+		err = prallel.Slice(det, fnc) // TODO fix package name
+		if err != nil {
+			return nil, tracer.Mask(err)
 		}
 	}
 
@@ -67,45 +77,45 @@ func (h *Handler) pipeline(det []detail) ([]pipeline, error) {
 // append manages the skipping behaviour of already observed pipeline
 // executions, as well as those pipeline executions that occured in the past
 // before the internal start time.
-func (h *Handler) append(pip []pipeline, sum types.PipelineExecutionSummary) []pipeline {
+func (h *Handler) append(pip []pipeline, out types.PipelineExecutionSummary) []pipeline {
 	// We skip all pipeline executions that are too far in the past, given
 	// Specta's own launch time.
-	if sum.StartTime.Before(h.sta) {
+	if out.StartTime.Before(h.sta) {
 		return pip
 	}
 
 	// We skip all pipeline executions that we already observed, given the
 	// cached execution ID.
-	if h.cac.Contains(*sum.PipelineExecutionId) {
+	if h.cac.Contains(*out.PipelineExecutionId) {
 		return pip
 	}
 
 	// We skip all pipeline executions that have not yet completed, given the
 	// pipeline status string.
-	if pipSkp(sum.Status) {
+	if pipSkp(out.Status) {
 		return pip
 	}
 
 	var lat time.Duration
 	{
-		lat = sum.LastUpdateTime.Sub(*sum.StartTime)
+		lat = out.LastUpdateTime.Sub(*out.StartTime)
 	}
 
 	var suc string
-	if sum.Status == types.PipelineExecutionStatusSucceeded {
+	if out.Status == types.PipelineExecutionStatusSucceeded {
 		suc = "true"
 	} else {
 		suc = "false"
 	}
 
 	pip = append(pip, pipeline{
-		eid: *sum.PipelineExecutionId,
+		eid: *out.PipelineExecutionId,
 		lat: lat,
 		suc: suc,
 	})
 
 	{
-		h.cac.Add(*sum.PipelineExecutionId, struct{}{})
+		h.cac.Add(*out.PipelineExecutionId, struct{}{})
 	}
 
 	return pip

--- a/pkg/worker/handler/endpoint/detail.go
+++ b/pkg/worker/handler/endpoint/detail.go
@@ -1,0 +1,75 @@
+package endpoint
+
+type detail struct {
+	// lab is the metric label used to instrument this service endpoint in
+	// Grafana.
+	lab string
+	// url is the list of HTTPS endpoints to verify for this service.
+	url []string
+}
+
+// detail returns a hard coded list of environment specific service endpoints to
+// verify.
+func (h *Handler) detail() ([]detail, error) {
+	var det map[string][]detail
+	{
+		det = map[string][]detail{
+			"testing": {
+				{
+					lab: "explorer",
+					url: []string{"https://explorer.testing.splits.org"},
+				},
+				{
+					lab: "server",
+					url: []string{"https://server.testing.splits.org/metrics"},
+				},
+				{
+					lab: "specta",
+					url: []string{"https://specta.testing.splits.org/metrics"},
+				},
+				{
+					lab: "teams",
+					url: []string{"https://teams.testing.splits.org"},
+				},
+			},
+			"staging": {
+				{
+					lab: "explorer",
+					url: []string{"https://explorer.staging.splits.org"},
+				},
+				{
+					lab: "server",
+					url: []string{"https://server.staging.splits.org/metrics"},
+				},
+				{
+					lab: "specta",
+					url: []string{"https://specta.staging.splits.org/metrics"},
+				},
+				{
+					lab: "teams",
+					url: []string{"https://teams.staging.splits.org"},
+				},
+			},
+			"production": {
+				{
+					lab: "explorer",
+					url: []string{"https://explorer.production.splits.org", "https://app.splits.org"},
+				},
+				{
+					lab: "server",
+					url: []string{"https://server.production.splits.org/metrics", "https://api.splits.org/metrics"},
+				},
+				{
+					lab: "specta",
+					url: []string{"https://specta.production.splits.org/metrics"},
+				},
+				{
+					lab: "teams",
+					url: []string{"https://teams.production.splits.org", "https://teams.splits.org"},
+				},
+			},
+		}
+	}
+
+	return det[h.env.Environment], nil
+}

--- a/pkg/worker/handler/endpoint/endpoint.go
+++ b/pkg/worker/handler/endpoint/endpoint.go
@@ -21,7 +21,7 @@ func (h *Handler) endpoint(det []detail) ([]endpoint, error) {
 
 	fnc := func(_ int, d detail) error {
 		var lis []float64
-		
+
 		for _, x := range d.url {
 			var hlt int
 			{

--- a/pkg/worker/handler/endpoint/endpoint.go
+++ b/pkg/worker/handler/endpoint/endpoint.go
@@ -1,0 +1,83 @@
+package endpoint
+
+import (
+	"net/http"
+	"slices"
+
+	"github.com/xh3b4sd/choreo/parallel"
+	"github.com/xh3b4sd/tracer"
+)
+
+type endpoint struct {
+	// hlt is the service endpoint health, either 0.0 or 1.0.
+	hlt float64
+	// lab is the respective service label, e.g. explorer or specta.
+	lab string
+}
+
+func (h *Handler) endpoint(det []detail) ([]endpoint, error) {
+	var end []endpoint
+	var err error
+
+	fnc := func(_ int, d detail) error {
+		var lis []float64
+		for _, x := range d.url {
+			var hlt int
+			{
+				hlt = musHlt(x)
+			}
+
+			if hlt != 1 {
+				h.log.Log(
+					"level", "info",
+					"message", "observed non-ok status code",
+					"url", x,
+				)
+			}
+
+			{
+				lis = append(lis, float64(hlt))
+			}
+		}
+
+		{
+			end = append(end, endpoint{
+				hlt: slices.Min(lis),
+				lab: d.lab,
+			})
+		}
+
+		return nil
+	}
+
+	{
+		err = parallel.Slice(det, fnc)
+		if err != nil {
+			return nil, tracer.Mask(err)
+		}
+	}
+
+	return end, nil
+}
+
+func musHlt(url string) int {
+	var err error
+
+	var res *http.Response
+	{
+		res, err = http.Get(url)
+		if err != nil {
+			return 0
+		}
+	}
+
+	{
+		defer res.Body.Close()
+	}
+
+	if res.StatusCode == http.StatusOK {
+		return 1
+	}
+
+	return 0
+}

--- a/pkg/worker/handler/endpoint/endpoint.go
+++ b/pkg/worker/handler/endpoint/endpoint.go
@@ -21,6 +21,7 @@ func (h *Handler) endpoint(det []detail) ([]endpoint, error) {
 
 	fnc := func(_ int, d detail) error {
 		var lis []float64
+		
 		for _, x := range d.url {
 			var hlt int
 			{

--- a/pkg/worker/handler/endpoint/ensure.go
+++ b/pkg/worker/handler/endpoint/ensure.go
@@ -1,60 +1,34 @@
 package endpoint
 
 import (
-	"net/http"
-	"strconv"
-
 	"github.com/xh3b4sd/tracer"
 )
 
 func (h *Handler) Ensure() error {
 	var err error
 
-	for k, v := range mapping {
-		for _, x := range v[h.env.Environment] {
-			var sta int
-			{
-				sta = musSta(x)
-			}
+	var det []detail
+	{
+		det, err = h.detail()
+		if err != nil {
+			return tracer.Mask(err)
+		}
+	}
 
-			var hlt float64
-			if sta == http.StatusOK {
-				hlt = 1
-			} else {
-				h.log.Log(
-					"level", "info",
-					"message", "observed non-ok status code",
-					"url", x,
-					"code", strconv.Itoa(sta),
-				)
-			}
+	var end []endpoint
+	{
+		end, err = h.endpoint(det)
+		if err != nil {
+			return tracer.Mask(err)
+		}
+	}
 
-			{
-				err = h.reg.Gauge(Metric, hlt, map[string]string{"service": k})
-				if err != nil {
-					return tracer.Mask(err)
-				}
-			}
+	for _, x := range end {
+		err = h.reg.Gauge(Metric, x.hlt, map[string]string{"service": x.lab})
+		if err != nil {
+			return tracer.Mask(err)
 		}
 	}
 
 	return nil
-}
-
-func musSta(url string) int {
-	var err error
-
-	var res *http.Response
-	{
-		res, err = http.Get(url)
-		if err != nil {
-			return 0
-		}
-	}
-
-	{
-		defer res.Body.Close()
-	}
-
-	return res.StatusCode
 }

--- a/pkg/worker/handler/endpoint/handler.go
+++ b/pkg/worker/handler/endpoint/handler.go
@@ -15,31 +15,6 @@ const (
 	Metric = "http_endpoint_health"
 )
 
-var (
-	mapping = map[string]map[string][]string{
-		"explorer": {
-			"testing":    {"https://explorer.testing.splits.org"},
-			"staging":    {"https://explorer.staging.splits.org"},
-			"production": {"https://explorer.production.splits.org", "https://app.splits.org"},
-		},
-		"server": {
-			"testing":    {"https://server.testing.splits.org/metrics"},
-			"staging":    {"https://server.staging.splits.org/metrics"},
-			"production": {"https://server.production.splits.org/metrics", "https://api.splits.org/metrics"},
-		},
-		"specta": {
-			"testing":    {"https://specta.testing.splits.org/metrics"},
-			"staging":    {"https://specta.staging.splits.org/metrics"},
-			"production": {"https://specta.production.splits.org/metrics"},
-		},
-		"teams": {
-			"testing":    {"https://teams.testing.splits.org"},
-			"staging":    {"https://teams.staging.splits.org"},
-			"production": {"https://teams.production.splits.org", "https://teams.splits.org"},
-		},
-	}
-)
-
 type Config struct {
 	Env envvar.Env
 	Log logger.Interface


### PR DESCRIPTION
Towards https://linear.app/splits/issue/PE-4424/run-spectas-exporter-workloads-in-parallel-for-more-timely-worker. This change runs various tasks inside some of the slower worker handlers concurrently, so that we can shave off a couple of seconds from the execution time in each loop. Functionally nothing should change. This is only to make the implementation more efficient at runtime. This change may also showcase how to improve the runtime latency of certain background jobs. The trigger for this change was the graph of the worker latency percentiles in the Specta / Service dashboard.

<img width="1465" height="737" alt="Screenshot 2025-07-22 at 21 52 37" src="https://github.com/user-attachments/assets/f19f9a8e-9e5a-4677-bc20-e99f7e5e7299" />


