### PR TITLE
use linter action for workflow to test caching

### DIFF
--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -9,6 +9,9 @@ name: "go-build"
 
 on: "push"
 
+permissions:
+  contents: read
+
 jobs:
   go-build:
     runs-on: "ubuntu-latest"
@@ -27,22 +30,15 @@ jobs:
           go mod tidy
           git diff --exit-code
 
-      - name: "Run Go Build"
-        env:
-          CGO_ENABLED: "0"
-        run: |
-          go build .
-
-      - name: "Check Go Tests"
-        run: |
-          go test ./... -race
+      - name: "Check Go Linters"
+        uses: "golangci/golangci-lint-action@v8"
+        with:
+          version: "v1.64.5"
 
       - name: "Check Go Formatting"
         run: |
           test -z $(gofmt -l -s .)
 
-      - name: "Check Go Linters"
+      - name: "Check Go Tests"
         run: |
-          curl -LOs https://github.com/golangci/golangci-lint/releases/download/v1.64.5/golangci-lint-1.64.5-linux-amd64.tar.gz
-          tar -xzf golangci-lint-1.64.5-linux-amd64.tar.gz
-          ./golangci-lint-1.64.5-linux-amd64/golangci-lint run
+          go test ./... -race

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: "Check Go Linters"
         uses: "golangci/golangci-lint-action@v8"
         with:
-          version: "v1.64.5"
+          version: "latest"
 
       - name: "Check Go Formatting"
         run: |

--- a/cmd/version/run.go
+++ b/cmd/version/run.go
@@ -2,19 +2,28 @@ package version
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/0xSplits/specta/pkg/runtime"
 	"github.com/spf13/cobra"
+	"github.com/xh3b4sd/tracer"
 )
 
 type run struct{}
 
 func (r *run) run(cmd *cobra.Command, arg []string) {
-	fmt.Fprintf(os.Stdout, "Git Sha       %s\n", runtime.Sha())
-	fmt.Fprintf(os.Stdout, "Git Tag       %s\n", runtime.Tag())
-	fmt.Fprintf(os.Stdout, "Repository    %s\n", runtime.Src())
-	fmt.Fprintf(os.Stdout, "Go Arch       %s\n", runtime.Arc())
-	fmt.Fprintf(os.Stdout, "Go OS         %s\n", runtime.Gos())
-	fmt.Fprintf(os.Stdout, "Go Version    %s\n", runtime.Ver())
+	mustPrint(os.Stdout, "Git Sha       %s\n", runtime.Sha())
+	mustPrint(os.Stdout, "Git Tag       %s\n", runtime.Tag())
+	mustPrint(os.Stdout, "Repository    %s\n", runtime.Src())
+	mustPrint(os.Stdout, "Go Arch       %s\n", runtime.Arc())
+	mustPrint(os.Stdout, "Go OS         %s\n", runtime.Gos())
+	mustPrint(os.Stdout, "Go Version    %s\n", runtime.Ver())
+}
+
+func mustPrint(w io.Writer, f string, a ...any) {
+	_, err := fmt.Fprintf(w, f, a...)
+	if err != nil {
+		tracer.Panic(tracer.Mask(err))
+	}
 }

--- a/cmd/version/run.go
+++ b/cmd/version/run.go
@@ -12,7 +12,7 @@ import (
 
 type run struct{}
 
-func (r *run) run(cmd *cobra.Command, arg []string) {
+func (r *run) run(_ *cobra.Command, _ []string) {
 	mustPrint(os.Stdout, "Git Sha       %s\n", runtime.Sha())
 	mustPrint(os.Stdout, "Git Tag       %s\n", runtime.Tag())
 	mustPrint(os.Stdout, "Repository    %s\n", runtime.Src())

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -6,7 +6,6 @@ import (
 	"github.com/0xSplits/specta/pkg/runtime"
 	"github.com/xh3b4sd/logger"
 	"go.opentelemetry.io/otel/metric"
-	otelmetric "go.opentelemetry.io/otel/metric"
 )
 
 type Config struct {
@@ -16,7 +15,7 @@ type Config struct {
 type Daemon struct {
 	env envvar.Env
 	log logger.Interface
-	met otelmetric.Meter
+	met metric.Meter
 }
 
 func New(c Config) *Daemon {

--- a/pkg/worker/handler/endpoint/endpoint.go
+++ b/pkg/worker/handler/endpoint/endpoint.go
@@ -73,7 +73,7 @@ func musHlt(url string) int {
 	}
 
 	{
-		defer res.Body.Close()
+		defer res.Body.Close() //nolint:errcheck
 	}
 
 	if res.StatusCode == http.StatusOK {


### PR DESCRIPTION
I noticed that the linter became super slow in CI due to all the AWS SDK dependencies we have here. In this change we improve the build performance by using the official linter action that automates caching for us under the hood. 