### PR TITLE
allow kayron related stacks and containers to be scraped

### DIFF
--- a/pkg/worker/handler/build/detail.go
+++ b/pkg/worker/handler/build/detail.go
@@ -21,6 +21,12 @@ func (h *Handler) detail() ([]detail, error) {
 	{
 		det = []detail{
 			{
+				repo:  "kayron",
+				label: "kayron",
+				check: "go-build",
+				image: "docker-release",
+			},
+			{
 				repo:  "specta",
 				label: "specta",
 				check: "go-build",

--- a/pkg/worker/handler/build/handler.go
+++ b/pkg/worker/handler/build/handler.go
@@ -55,7 +55,7 @@ func New(c Config) *Handler {
 			Des: "the total amount of build container executions",
 			Lab: map[string][]string{
 				"platform":   {"github"},
-				"repository": {"server", "specta"},
+				"repository": {"kayron", "server", "specta"},
 				"success":    {"true", "false"},
 				"workflow":   {"check", "image"},
 			},
@@ -73,7 +73,7 @@ func New(c Config) *Handler {
 			Des: "the time it takes for build container executions to complete",
 			Lab: map[string][]string{
 				"platform":   {"github"},
-				"repository": {"server", "specta"},
+				"repository": {"kayron", "server", "specta"},
 				"success":    {"true", "false"},
 				"workflow":   {"check", "image"},
 			},

--- a/pkg/worker/handler/container/handler.go
+++ b/pkg/worker/handler/container/handler.go
@@ -52,7 +52,7 @@ func New(c Config) *Handler {
 		gau[Metric] = recorder.NewGauge(recorder.GaugeConfig{
 			Des: "the health status of ecs service containers",
 			Lab: map[string][]string{
-				"service": {"alloy", "graphql", "otel-collector", "server", "specta", "worker"},
+				"service": {"alloy", "graphql", "kayron", "otel-collector", "server", "specta", "worker"},
 			},
 			Met: c.Met,
 			Nam: Metric,

--- a/pkg/worker/handler/stack/handler.go
+++ b/pkg/worker/handler/stack/handler.go
@@ -24,6 +24,7 @@ var (
 		"DeploymentStack": "deployment",
 		"DiscoveryStack":  "discovery",
 		"FargateStack":    "fargate",
+		"KayronStack":     "kayron",
 		"RdsStack":        "database",
 		"ServerStack":     "server",
 		"SpectaStack":     "specta",
@@ -66,7 +67,7 @@ func New(c Config) *Handler {
 		gau[Metric] = recorder.NewGauge(recorder.GaugeConfig{
 			Des: "the health status of cloudformation stacks",
 			Lab: map[string][]string{
-				"stack": {"root", "alloy", "cache", "database", "deployment", "discovery", "fargate", "network", "specta", "server"},
+				"stack": {"root", "alloy", "cache", "database", "deployment", "discovery", "fargate", "kayron", "network", "specta", "server"},
 			},
 			Met: c.Met,
 			Nam: Metric,


### PR DESCRIPTION
Fixes https://linear.app/splits/issue/PE-4661/add-kayron-labels-to-specta-whitelist. I tested this locally using the SSO read-only credentials. Kayron specific resources can now be scraped.