### PR TITLE
remove branches directive from docker push workflow

### DIFF
--- a/.github/workflows/docker-push.yaml
+++ b/.github/workflows/docker-push.yaml
@@ -6,10 +6,6 @@ on:
     # skip running the workflow in branches that dependabot presumably created.
     branches-ignore:
       - "dependabot/**"
-    # Trigger this workflow on all branch updates where a new commit is being
-    # pushed.
-    branches:
-      - "**"
     # Trigger this workflow for all new releases that create a Git tag.
     tags:
       - "v*.*.*"


### PR DESCRIPTION
Github silently failed on me with the last pull request and I did not manually check the actions tab. Round-tripping this thing here. 