### PR TITLE
support splits lite deployment for observability

### DIFF
--- a/pkg/worker/handler/build/detail.go
+++ b/pkg/worker/handler/build/detail.go
@@ -38,6 +38,12 @@ func (h *Handler) detail() ([]detail, error) {
 				check: "typescript-server",
 				image: "docker-push",
 			},
+			{
+				repo:  "splits-lite",
+				label: "splits-lite",
+				check: "typescript",
+				image: "docker-push",
+			},
 		}
 	}
 

--- a/pkg/worker/handler/build/handler.go
+++ b/pkg/worker/handler/build/handler.go
@@ -55,7 +55,7 @@ func New(c Config) *Handler {
 			Des: "the total amount of build container executions",
 			Lab: map[string][]string{
 				"platform":   {"github"},
-				"repository": {"kayron", "server", "specta"},
+				"repository": {"kayron", "server", "specta", "splits-lite"},
 				"success":    {"true", "false"},
 				"workflow":   {"check", "image"},
 			},
@@ -73,7 +73,7 @@ func New(c Config) *Handler {
 			Des: "the time it takes for build container executions to complete",
 			Lab: map[string][]string{
 				"platform":   {"github"},
-				"repository": {"kayron", "server", "specta"},
+				"repository": {"kayron", "server", "specta", "splits-lite"},
 				"success":    {"true", "false"},
 				"workflow":   {"check", "image"},
 			},

--- a/pkg/worker/handler/container/handler.go
+++ b/pkg/worker/handler/container/handler.go
@@ -52,7 +52,7 @@ func New(c Config) *Handler {
 		gau[Metric] = recorder.NewGauge(recorder.GaugeConfig{
 			Des: "the health status of ecs service containers",
 			Lab: map[string][]string{
-				"service": {"alloy", "graphql", "kayron", "otel-collector", "server", "specta", "worker"},
+				"service": {"alloy", "graphql", "kayron", "otel-collector", "server", "specta", "splits-lite", "worker"},
 			},
 			Met: c.Met,
 			Nam: Metric,

--- a/pkg/worker/handler/container/service.go
+++ b/pkg/worker/handler/container/service.go
@@ -66,6 +66,17 @@ func (h *Handler) append(ser []service, out types.Service) []service {
 		tag = serTag(out.Tags)
 	}
 
+	if *out.Status == "INACTIVE" {
+		// There might be inactive stacks with our desired service labels in case we
+		// deployed CloudFormation stacks multiple times during testing. We only
+		// want to monitor those stacks that are still active, because the inactive
+		// versions have most likely been deleted already.
+
+		{
+			return ser
+		}
+	}
+
 	if tag == "" {
 		h.log.Log(
 			"level", "warning",

--- a/pkg/worker/handler/endpoint/detail.go
+++ b/pkg/worker/handler/endpoint/detail.go
@@ -28,6 +28,10 @@ func (h *Handler) detail() ([]detail, error) {
 					url: []string{"https://specta.testing.splits.org/metrics"},
 				},
 				{
+					lab: "splits-lite",
+					url: []string{"https://lite.testing.splits.org"},
+				},
+				{
 					lab: "teams",
 					url: []string{"https://teams.testing.splits.org"},
 				},
@@ -46,6 +50,10 @@ func (h *Handler) detail() ([]detail, error) {
 					url: []string{"https://specta.staging.splits.org/metrics"},
 				},
 				{
+					lab: "splits-lite",
+					url: []string{"https://lite.staging.splits.org"},
+				},
+				{
 					lab: "teams",
 					url: []string{"https://teams.staging.splits.org"},
 				},
@@ -62,6 +70,10 @@ func (h *Handler) detail() ([]detail, error) {
 				{
 					lab: "specta",
 					url: []string{"https://specta.production.splits.org/metrics"},
+				},
+				{
+					lab: "splits-lite",
+					url: []string{"https://lite.production.splits.org", "https://lite.splits.org"},
 				},
 				{
 					lab: "teams",

--- a/pkg/worker/handler/endpoint/handler.go
+++ b/pkg/worker/handler/endpoint/handler.go
@@ -43,7 +43,7 @@ func New(c Config) *Handler {
 		gau[Metric] = recorder.NewGauge(recorder.GaugeConfig{
 			Des: "the health status of an http endpoint",
 			Lab: map[string][]string{
-				"service": {"explorer", "server", "specta", "teams"},
+				"service": {"explorer", "server", "specta", "splits-lite", "teams"},
 			},
 			Met: c.Met,
 			Nam: Metric,

--- a/pkg/worker/handler/stack/handler.go
+++ b/pkg/worker/handler/stack/handler.go
@@ -25,6 +25,7 @@ var (
 		"DiscoveryStack":  "discovery",
 		"FargateStack":    "fargate",
 		"KayronStack":     "kayron",
+		"LiteStack":       "splits-lite",
 		"RdsStack":        "database",
 		"ServerStack":     "server",
 		"SpectaStack":     "specta",
@@ -67,7 +68,7 @@ func New(c Config) *Handler {
 		gau[Metric] = recorder.NewGauge(recorder.GaugeConfig{
 			Des: "the health status of cloudformation stacks",
 			Lab: map[string][]string{
-				"stack": {"root", "alloy", "cache", "database", "deployment", "discovery", "fargate", "kayron", "network", "specta", "server"},
+				"stack": {"root", "alloy", "cache", "database", "deployment", "discovery", "fargate", "kayron", "network", "server", "specta", "splits-lite"},
 			},
 			Met: c.Met,
 			Nam: Metric,


### PR DESCRIPTION
Towards https://linear.app/splits/issue/PE-4711/run-splits-lite-in-cloudformation-and-deploy-via-kayron. 

```
aws_cloudformation_stack_health{env="testing",otel_scope_name="specta.testing.splits.org",otel_scope_schema_url="",otel_scope_version="n/a",stack="splits-lite"} 1
...
aws_ecs_container_health{env="testing",otel_scope_name="specta.testing.splits.org",otel_scope_schema_url="",otel_scope_version="n/a",service="splits-lite"} 1
...
http_endpoint_health{env="testing",otel_scope_name="specta.testing.splits.org",otel_scope_schema_url="",otel_scope_version="n/a",service="splits-lite"} 1
```