### PR TITLE
PE-7055: remove Pulsar from build/container/stack registries

### DIFF
--- a/pkg/worker/handler/build/detail.go
+++ b/pkg/worker/handler/build/detail.go
@@ -27,12 +27,6 @@ func (h *Handler) detail() ([]detail, error) {
 				image: "docker-push",
 			},
 			{
-				repo:  "pulsar",
-				label: "pulsar",
-				check: "go-build",
-				image: "docker-push",
-			},
-			{
 				repo:  "specta",
 				label: "specta",
 				check: "go-build",

--- a/pkg/worker/handler/build/handler.go
+++ b/pkg/worker/handler/build/handler.go
@@ -59,7 +59,7 @@ func New(c Config) *Handler {
 			Des: "the total amount of build container executions",
 			Lab: map[string][]string{
 				"platform":   {"github"},
-				"repository": {"kayron", "pulsar", "server", "specta", "splits-lite"},
+				"repository": {"kayron", "server", "specta", "splits-lite"},
 				"success":    {"true", "false"},
 				"workflow":   {"check", "image"},
 			},
@@ -77,7 +77,7 @@ func New(c Config) *Handler {
 			Des: "the time it takes for build container executions to complete",
 			Lab: map[string][]string{
 				"platform":   {"github"},
-				"repository": {"kayron", "pulsar", "server", "specta", "splits-lite"},
+				"repository": {"kayron", "server", "specta", "splits-lite"},
 				"success":    {"true", "false"},
 				"workflow":   {"check", "image"},
 			},

--- a/pkg/worker/handler/container/handler.go
+++ b/pkg/worker/handler/container/handler.go
@@ -52,7 +52,7 @@ func New(c Config) *Handler {
 		gau[Metric] = recorder.NewGauge(recorder.GaugeConfig{
 			Des: "the health status of ecs service containers",
 			Lab: map[string][]string{
-				"service": {"alloy", "graphql", "kayron", "otel-collector", "pulsar", "server", "specta", "splits-lite", "worker"},
+				"service": {"alloy", "graphql", "kayron", "otel-collector", "server", "specta", "splits-lite", "worker"},
 			},
 			Met: c.Met,
 			Nam: Metric,

--- a/pkg/worker/handler/stack/handler.go
+++ b/pkg/worker/handler/stack/handler.go
@@ -26,7 +26,6 @@ var (
 		"FargateStack":    "fargate",
 		"KayronStack":     "kayron",
 		"LiteStack":       "splits-lite",
-		"PulsarStack":     "pulsar",
 		"RdsStack":        "database",
 		"ServerStack":     "server",
 		"SpectaStack":     "specta",
@@ -69,7 +68,7 @@ func New(c Config) *Handler {
 		gau[Metric] = recorder.NewGauge(recorder.GaugeConfig{
 			Des: "the health status of cloudformation stacks",
 			Lab: map[string][]string{
-				"stack": {"root", "alloy", "cache", "database", "deployment", "discovery", "fargate", "kayron", "network", "pulsar", "server", "specta", "splits-lite"},
+				"stack": {"root", "alloy", "cache", "database", "deployment", "discovery", "fargate", "kayron", "network", "server", "specta", "splits-lite"},
 			},
 			Met: c.Met,
 			Nam: Metric,


### PR DESCRIPTION
## Summary

Pulsar (real-time transaction indexing) is being decommissioned. This drops `pulsar` from the hard coded registries in the worker handlers:

- `build/detail.go` — remove the `pulsar` build detail entry
- `build/handler.go` — remove `"pulsar"` from the `repository` metric labels (total + duration)
- `container/handler.go` — remove `"pulsar"` from the ECS `service` health metric labels
- `stack/handler.go` — remove the `PulsarStack` → `pulsar` mapping and `"pulsar"` from the CloudFormation `stack` health metric labels

Companion to 0xSplits/infrastructure#68 (removes the `PulsarStack` CloudFormation template).

Linear: PE-7055

🤖 Generated with [Claude Code](https://claude.com/claude-code)