### PR TITLE
whitelist indexing microservice for container health metric

### DIFF
--- a/pkg/worker/handler/container/handler.go
+++ b/pkg/worker/handler/container/handler.go
@@ -52,7 +52,7 @@ func New(c Config) *Handler {
 		gau[Metric] = recorder.NewGauge(recorder.GaugeConfig{
 			Des: "the health status of ecs service containers",
 			Lab: map[string][]string{
-				"service": {"alloy", "graphql", "kayron", "otel-collector", "server", "specta", "splits-lite", "worker"},
+				"service": {"alloy", "graphql", "indexing", "kayron", "otel-collector", "server", "specta", "splits-lite", "worker"},
 			},
 			Met: c.Met,
 			Nam: Metric,


### PR DESCRIPTION
Adds `indexing` to the `service` label whitelist in the container handler so the new ECS indexing service stops failing the `aws_ecs_container_health` gauge write.

Without this, every container worker tick fails with `labelValueWhitelistError` once the indexing service is encountered.